### PR TITLE
fix: Excel preview JSON serialization + Docker race condition

### DIFF
--- a/backend/excel_importer/date_utils.py
+++ b/backend/excel_importer/date_utils.py
@@ -9,6 +9,8 @@ for comparison during Time-Window Sync.
 import datetime
 import re
 
+import pandas as pd
+
 
 def parse_date(value):
     """
@@ -19,7 +21,7 @@ def parse_date(value):
     - Datetime objects
     - Pandas Timestamps
     - Excel serial numbers (days since 1899-12-30)
-    - None, empty strings, and invalid values → returns None
+    - None, empty strings, pandas NaT, and invalid values → returns None
 
     Args:
         value: The date value to parse (str, datetime, Timestamp, int, None)
@@ -28,6 +30,12 @@ def parse_date(value):
         str: Normalized date string 'YYYY-MM-DD', or None if unparseable.
     """
     if value is None:
+        return None
+
+    # Handle pandas NaT (Not a Time) — must be checked BEFORE datetime check
+    # because NaT inherits from datetime.datetime in some pandas versions
+    # but does NOT support strftime()
+    if isinstance(value, type(pd.NaT)):
         return None
 
     # Handle datetime objects (includes pandas Timestamp)

--- a/backend/excel_importer/tests/test_date_utils.py
+++ b/backend/excel_importer/tests/test_date_utils.py
@@ -65,6 +65,12 @@ class ParseDateTest(TestCase):
         result = parse_date(ts)
         self.assertEqual(result, "2025-06-20")
 
+    def test_parse_pandas_nat(self):
+        """Given a pandas NaT (empty date cell), returns None instead of crashing."""
+        import pandas as pd
+        result = parse_date(pd.NaT)
+        self.assertIsNone(result)
+
     def test_parse_day_month_year_format(self):
         """Given '20/06/2025' (DD/MM/YYYY), returns normalized '2025-06-20'."""
         result = parse_date("20/06/2025")

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -3,6 +3,9 @@ from rest_framework.parsers import FileUploadParser
 from rest_framework.response import Response
 from rest_framework import status as http_status
 from django.shortcuts import get_object_or_404
+import pandas as pd
+import numpy as np
+import datetime
 from quality_data.models import QualityQcFa, SecondsA4, SecondsGeneral, Container, ExcelSyncSession
 from excel_importer.handler_service import (
     load_and_clean,
@@ -47,6 +50,44 @@ def _get_incremental_rows(df, model_class, **filters):
         return df.iloc[0:0]
 
     return df.tail(rows_to_insert).copy()
+
+
+def _df_to_json_safe(df):
+    """
+    Convert a DataFrame to a list of dicts with JSON-serializable values.
+
+    Handles:
+    - pandas.Timestamp / datetime → ISO date string (YYYY-MM-DD)
+    - numpy.integer / numpy.floating → Python int / float
+    - numpy.bool_ → Python bool
+    - pandas.NaT / None → None
+    """
+    if df is None or df.empty:
+        return []
+
+    records = df.to_dict('records')
+    result = []
+    for row in records:
+        clean_row = {}
+        for key, value in row.items():
+            if value is None or pd.isna(value):
+                clean_row[key] = None
+            elif isinstance(value, (pd.Timestamp, datetime.datetime)):
+                clean_row[key] = value.strftime("%Y-%m-%d")
+            elif isinstance(value, datetime.date):
+                clean_row[key] = value.strftime("%Y-%m-%d")
+            elif isinstance(value, (np.integer,)):
+                clean_row[key] = int(value)
+            elif isinstance(value, (np.floating,)):
+                clean_row[key] = float(value)
+            elif isinstance(value, (np.bool_,)):
+                clean_row[key] = bool(value)
+            elif isinstance(value, np.ndarray):
+                clean_row[key] = value.tolist()
+            else:
+                clean_row[key] = value
+        result.append(clean_row)
+    return result
 
 class Process(APIView):
     parser_classes = [FileUploadParser]
@@ -221,31 +262,31 @@ class ExcelPreviewView(APIView):
                 file_obj, QC_FA_PLANT_REMAP, QC_FA_PLANT_NUMERIC_COLUMNS,
                 QC_FA_PLANT_AMOUNT_DEFEACTS_FIELDS, *SHEET_NAMES[0],
             )
-            dataframes["qc_fa_plant"] = qc_fa_plant_df.to_dict('records')
+            dataframes["qc_fa_plant"] = _df_to_json_safe(qc_fa_plant_df)
 
             qc_fa_customer_df = load_and_clean(
                 file_obj, QC_FA_CUSTOMER_REMAP, QC_FA_CUSTOMER_NUMERIC_COLUMNS,
                 QC_FA_CUSTOMER_AMOUNT_DEFEACTS_FIELDS, *SHEET_NAMES[1],
             )
-            dataframes["qc_fa_customer"] = qc_fa_customer_df.to_dict('records')
+            dataframes["qc_fa_customer"] = _df_to_json_safe(qc_fa_customer_df)
 
             seconds_a4_df = load_and_clean(
                 file_obj, SECONDS_A4_REMAP, SECONDS_A4_NUMERIC_COLUMNS,
                 None, *SHEET_NAMES[2],
             )
-            dataframes["seconds_a4"] = seconds_a4_df.to_dict('records')
+            dataframes["seconds_a4"] = _df_to_json_safe(seconds_a4_df)
 
             seconds_general_df = load_and_clean(
                 file_obj, SECONDS_GENERAL_REMAP, SECONDS_GENERAL_NUMERIC_COLUMNS,
                 None, *SHEET_NAMES[3],
             )
-            dataframes["seconds_general"] = seconds_general_df.to_dict('records')
+            dataframes["seconds_general"] = _df_to_json_safe(seconds_general_df)
 
             container_df = load_and_clean(
                 file_obj, CONTAINER_REMAP, CONTAINER_NUMERIC_COLUMNS,
                 CONTAINER_AMOUNT_DEFEACTS_FIELDS, *SHEET_NAMES[4],
             )
-            dataframes["container"] = container_df.to_dict('records')
+            dataframes["container"] = _df_to_json_safe(container_df)
 
             # Create session with preview
             session = create_session_from_dataframes(dataframes)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,17 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: postgress
-      POSTGRES_PASSWORD: postgress*
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: appdb
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d appdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
 
   backend:
@@ -29,7 +35,8 @@ services:
     env_file:
       - ./backend/.env
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - DJANGO_DEBUG=True
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

- **Fix `pd.NaT` crash in `parse_date()`**: Empty date cells in Excel return `pd.NaT` which passes `isinstance(x, datetime.datetime)` but doesn't support `strftime()`. Added explicit NaT check before datetime check + regression test.
- **Fix JSON serialization in `ExcelPreviewView`**: `df.to_dict('records')` preserves pandas/numpy types that Django's JSONField can't serialize. Added `_df_to_json_safe()` helper to convert to native Python types.
- **Fix Docker race condition**: Added PostgreSQL healthcheck + `condition: service_healthy` so Django waits for Postgres to be ready before running migrations.
- **Fix typo**: `postgress` → `postgres` in `POSTGRES_USER` and `POSTGRES_PASSWORD`.

## Files Changed

- `backend/excel_importer/date_utils.py` — Added `pd.NaT` check
- `backend/excel_importer/tests/test_date_utils.py` — Added `test_parse_pandas_nat`
- `backend/quality_data/views.py` — Added `_df_to_json_safe()` helper
- `docker-compose.yml` — Added healthcheck + fixed credentials typo

## Testing

- ✅ 14/14 `test_date_utils` tests passing (including new NaT test)
- ✅ Excel preview endpoint tested with real `.xlsx` file