### PR TITLE
feat(kpi): add dashboard view with 14 charts, filters, and volatile mode

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import Navbar from './Components/Navbar.jsx';
 import CaptureView from './views/CaptureView.jsx';
 import LoginView from './views/LoginView.jsx';
 import ExcelUploader from './Components/ExcelUploader.jsx';
+import DashboardView from './views/DashboardView.jsx';
 
 const STORAGE_KEY = 'rift-user';
 
@@ -25,6 +26,12 @@ function App() {
       return '';
     }
   });
+  const [volatileData, setVolatileData] = useState(null);
+
+  const handleVolatileDashboard = (data) => {
+    setVolatileData(data);
+    setActiveView('dashboard');
+  };
 
   const handleLogin = (userData) => {
     setUser(userData);
@@ -51,6 +58,7 @@ function App() {
         userRole={user.role} 
         activeView={activeView} 
         setActiveView={setActiveView} 
+        setVolatileData={setVolatileData}
         onLogout={handleLogout} 
       />
 
@@ -67,8 +75,12 @@ function App() {
               <p className="excel-subtitle">
                 Drag your file to ingest multiple records into the system.
               </p>
-              <ExcelUploader />
+              <ExcelUploader onVolatileDashboard={handleVolatileDashboard} />
             </div>
+          )}
+
+          {activeView === 'dashboard' && (
+            <DashboardView volatileData={volatileData} />
           )}
 
         </main>

--- a/frontend/src/Components/ExcelUploader.jsx
+++ b/frontend/src/Components/ExcelUploader.jsx
@@ -20,7 +20,7 @@ const SHEET_GROUPS_MAP = {
   ALL: ["QC FA Plant", "QC FA Customer", "SecondsA4", "Seconds General", "Container"] 
 };
 
-export default function ExcelUploader() {
+export default function ExcelUploader({ onVolatileDashboard }) {
   const [selectedFile, setSelectedFile] = useState(null);
   const [reportType, setReportType] = useState('QFA'); 
   const [errorMsg, setErrorMsg] = useState('');
@@ -239,6 +239,11 @@ export default function ExcelUploader() {
         <button className="ingesta-btn-primary full-width-btn" onClick={handleConfirm}>
           Confirm & Import All ({Object.values(previewStats || {}).reduce((sum, s) => sum + (s.total || 0), 0)} Records)
         </button>
+        {onVolatileDashboard && (
+          <button className="ingesta-btn-outline full-width-btn" onClick={() => onVolatileDashboard(previewStats)}>
+            View Dashboard
+          </button>
+        )}
         <button className="ingesta-btn-outline full-width-btn" onClick={handleReject}>
           <X size={18} />
           Cancel Import

--- a/frontend/src/Components/Sidebar.jsx
+++ b/frontend/src/Components/Sidebar.jsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import './Sidebar.css';
-import { Factory, Hand, Database, LogOut, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Factory, Hand, Database, LogOut, ChevronLeft, ChevronRight, ChartBar } from 'lucide-react';
 
-export default function Sidebar({ userRole, activeView, setActiveView, onLogout }) {
+export default function Sidebar({ userRole, activeView, setActiveView, setVolatileData, onLogout }) {
   const [isCollapsed, setIsCollapsed] = useState(false);
 
   return (
@@ -45,6 +45,17 @@ export default function Sidebar({ userRole, activeView, setActiveView, onLogout 
             >
               <Database className="sidebar-nav-icon" />
               {!isCollapsed && <span>Import Batches</span>}
+            </button>
+          )}
+
+          {userRole === 'manager' && (
+            <button 
+              className={`sidebar-nav-item ${activeView === 'dashboard' ? 'active' : ''}`} 
+              title={isCollapsed ? "Dashboard" : ""}
+              onClick={() => { setActiveView('dashboard'); setVolatileData(null); }}
+            >
+              <ChartBar className="sidebar-nav-icon" />
+              {!isCollapsed && <span>Dashboard</span>}
             </button>
           )}
           

--- a/frontend/src/Components/kpi/BarChartKpi.jsx
+++ b/frontend/src/Components/kpi/BarChartKpi.jsx
@@ -1,0 +1,37 @@
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+export default function BarChartKpi({ data = [], title, horizontal = false, color = '#3b82f6' }) {
+  const chartStyle = { margin: { top: 5, right: 30, left: 20, bottom: 5 } };
+
+  if (horizontal) {
+    return (
+      <div style={{ padding: '16px' }}>
+        {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data} layout="vertical" margin={chartStyle}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" />
+            <YAxis dataKey="label" type="category" width={100} />
+            <Tooltip />
+            <Bar dataKey="value" fill={color} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '16px' }}>
+      {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart data={data} margin={chartStyle}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="label" />
+          <YAxis />
+          <Tooltip />
+          <Bar dataKey="value" fill={color} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/DonutChartKpi.jsx
+++ b/frontend/src/Components/kpi/DonutChartKpi.jsx
@@ -1,0 +1,37 @@
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+
+export default function DonutChartKpi({ data = [], title }) {
+  const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4'];
+
+  const total = data.reduce((sum, item) => sum + item.value, 0);
+
+  const renderLabel = ({ name, percent }) => `${name}: ${(percent * 100).toFixed(1)}%`;
+
+  return (
+    <div style={{ padding: '16px' }}>
+      {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="value"
+            nameKey="name"
+            cx="50%"
+            cy="50%"
+            innerRadius={60}
+            outerRadius={100}
+            paddingAngle={2}
+            label={renderLabel}
+            labelLine={false}
+          >
+            {data.map((entry, index) => (
+              <Cell key={entry.name} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+          <Legend verticalAlign="bottom" height={36} />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/FilterBar.css
+++ b/frontend/src/Components/kpi/FilterBar.css
@@ -1,0 +1,153 @@
+.filter-bar {
+  background-color: var(--white);
+  border-radius: 12px;
+  padding: 20px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  margin-bottom: 24px;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 100px;
+  flex: 1;
+}
+
+.date-range-group {
+  min-width: 140px;
+}
+
+.filter-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.filter-input {
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: 'Inter', sans-serif;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  background-color: var(--white);
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(86, 126, 187, 0.15);
+}
+
+.filter-input::placeholder {
+  color: #9ca3af;
+}
+
+/* Remove spinner for number inputs */
+.filter-input[type="number"]::-webkit-inner-spin-button,
+.filter-input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.filter-input[type="number"] {
+  -moz-appearance: textfield;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.filter-btn-primary {
+  background-color: var(--primary);
+  color: var(--white);
+  padding: 10px 20px;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.filter-btn-primary:hover {
+  background-color: var(--primary-hover);
+}
+
+.filter-btn-outline {
+  background: transparent;
+  border: 2px solid var(--primary);
+  color: var(--primary);
+  padding: 8px 20px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: 'Inter', sans-serif;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.filter-btn-outline:hover {
+  background-color: var(--primary);
+  color: var(--white);
+}
+
+/* Responsive adjustments */
+@media (max-width: 1200px) {
+  .filter-row {
+    gap: 12px;
+  }
+
+  .filter-group {
+    min-width: 90px;
+  }
+
+  .date-range-group {
+    min-width: 120px;
+  }
+}
+
+@media (max-width: 768px) {
+  .filter-bar {
+    padding: 16px;
+  }
+
+  .filter-row {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .filter-group {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .date-range-group {
+    min-width: unset;
+  }
+
+  .filter-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .filter-btn-primary,
+  .filter-btn-outline {
+    width: 100%;
+  }
+}

--- a/frontend/src/Components/kpi/FilterBar.jsx
+++ b/frontend/src/Components/kpi/FilterBar.jsx
@@ -1,0 +1,116 @@
+import './FilterBar.css';
+
+export default function FilterBar({ filters, onFilterChange, onApply, onReset }) {
+  const handleChange = (field, value) => {
+    onFilterChange({ ...filters, [field]: value });
+  };
+
+  const handleDateRangeChange = (index, value) => {
+    const newRange = [...filters.date_range];
+    newRange[index] = value;
+    onFilterChange({ ...filters, date_range: newRange });
+  };
+
+  return (
+    <div className="filter-bar">
+      <div className="filter-row">
+        <div className="filter-group date-range-group">
+          <label className="filter-label">Desde</label>
+          <input
+            type="date"
+            className="filter-input"
+            value={filters.date_range[0] || ''}
+            onChange={(e) => handleDateRangeChange(0, e.target.value)}
+          />
+        </div>
+
+        <div className="filter-group date-range-group">
+          <label className="filter-label">Hasta</label>
+          <input
+            type="date"
+            className="filter-input"
+            value={filters.date_range[1] || ''}
+            onChange={(e) => handleDateRangeChange(1, e.target.value)}
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Semana</label>
+          <input
+            type="number"
+            className="filter-input"
+            min="1"
+            max="52"
+            value={filters.week}
+            onChange={(e) => handleChange('week', e.target.value)}
+            placeholder="1-52"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Team</label>
+          <input
+            type="number"
+            className="filter-input"
+            value={filters.team}
+            onChange={(e) => handleChange('team', e.target.value)}
+            placeholder="#"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Estilo</label>
+          <input
+            type="text"
+            className="filter-input"
+            value={filters.style}
+            onChange={(e) => handleChange('style', e.target.value)}
+            placeholder="Estilo"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Color</label>
+          <input
+            type="text"
+            className="filter-input"
+            value={filters.color}
+            onChange={(e) => handleChange('color', e.target.value)}
+            placeholder="Color"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Cliente</label>
+          <input
+            type="text"
+            className="filter-input"
+            value={filters.customer}
+            onChange={(e) => handleChange('customer', e.target.value)}
+            placeholder="Cliente"
+          />
+        </div>
+
+        <div className="filter-group">
+          <label className="filter-label">Batch</label>
+          <input
+            type="number"
+            className="filter-input"
+            value={filters.batch}
+            onChange={(e) => handleChange('batch', e.target.value)}
+            placeholder="#"
+          />
+        </div>
+      </div>
+
+      <div className="filter-actions">
+        <button className="filter-btn-primary" onClick={onApply}>
+          Aplicar Filtros
+        </button>
+        <button className="filter-btn-outline" onClick={onReset}>
+          Limpiar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/FilterBar.test.jsx
+++ b/frontend/src/Components/kpi/FilterBar.test.jsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FilterBar from './FilterBar';
+
+describe('FilterBar', () => {
+  const defaultFilters = {
+    date_range: ['', ''],
+    week: '',
+    team: '',
+    style: '',
+    color: '',
+    customer: '',
+    batch: '',
+  };
+
+  describe('Rendering', () => {
+    it('renders all 8 filter inputs', () => {
+      render(
+        <FilterBar
+          filters={defaultFilters}
+          onFilterChange={vi.fn()}
+          onApply={vi.fn()}
+          onReset={vi.fn()}
+        />
+      );
+
+      // 8 inputs: desde, hasta, week, team, style, color, customer, batch
+      const inputs = document.querySelectorAll('.filter-input');
+      expect(inputs).toHaveLength(8);
+    });
+
+    it('inputs reflect filters prop values', () => {
+      const filtersWithValues = {
+        date_range: ['2026-01-01', '2026-01-31'],
+        week: '5',
+        team: '2',
+        style: 'Style-X',
+        color: 'Rojo',
+        customer: 'Cliente-1',
+        batch: '10',
+      };
+
+      render(
+        <FilterBar
+          filters={filtersWithValues}
+          onFilterChange={vi.fn()}
+          onApply={vi.fn()}
+          onReset={vi.fn()}
+        />
+      );
+
+      const inputs = document.querySelectorAll('.filter-input');
+      // Inputs order: desde, hasta, week, team, style, color, customer, batch
+      expect(inputs[0]).toHaveValue('2026-01-01');
+      expect(inputs[1]).toHaveValue('2026-01-31');
+      expect(inputs[2]).toHaveValue(5);
+      expect(inputs[3]).toHaveValue(2);
+      expect(inputs[4]).toHaveValue('Style-X');
+      expect(inputs[5]).toHaveValue('Rojo');
+      expect(inputs[6]).toHaveValue('Cliente-1');
+      expect(inputs[7]).toHaveValue(10);
+    });
+  });
+
+  describe('Interactions', () => {
+    it('calls onFilterChange when input changes', () => {
+      const onFilterChange = vi.fn();
+      render(
+        <FilterBar
+          filters={defaultFilters}
+          onFilterChange={onFilterChange}
+          onApply={vi.fn()}
+          onReset={vi.fn()}
+        />
+      );
+
+      // Style input is the 5th input (index 4)
+      const inputs = document.querySelectorAll('.filter-input');
+      fireEvent.change(inputs[4], { target: { value: 'NewStyle' } });
+
+      expect(onFilterChange).toHaveBeenCalledWith(
+        expect.objectContaining({ style: 'NewStyle' })
+      );
+    });
+
+    it('calls onApply when Aplicar Filtros button is clicked', () => {
+      const onApply = vi.fn();
+      render(
+        <FilterBar
+          filters={defaultFilters}
+          onFilterChange={vi.fn()}
+          onApply={onApply}
+          onReset={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /aplicar filtros/i }));
+
+      expect(onApply).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onReset when Limpiar button is clicked', () => {
+      const onReset = vi.fn();
+      render(
+        <FilterBar
+          filters={defaultFilters}
+          onFilterChange={vi.fn()}
+          onApply={vi.fn()}
+          onReset={onReset}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /limpiar/i }));
+
+      expect(onReset).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/Components/kpi/HeatmapKpi.jsx
+++ b/frontend/src/Components/kpi/HeatmapKpi.jsx
@@ -1,0 +1,82 @@
+export default function HeatmapKpi({ data = [], title }) {
+  if (!data || data.length === 0) {
+    return (
+      <div style={{ padding: '16px' }}>
+        {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+        <div style={{ textAlign: 'center', color: '#666' }}>Sin datos</div>
+      </div>
+    );
+  }
+
+  const xLabels = [...new Set(data.map(d => d.x))].sort();
+  const yLabels = [...new Set(data.map(d => d.y))].sort();
+  const maxValue = Math.max(...data.map(d => d.value));
+  const minValue = Math.min(...data.map(d => d.value));
+
+  const getColor = (value) => {
+    if (maxValue === minValue) return '#22c55e';
+    const ratio = (value - minValue) / (maxValue - minValue);
+    if (ratio < 0.5) {
+      const r = Math.round(34 + (235 - 34) * (ratio * 2));
+      const g = Math.round(197 + (173 - 197) * (ratio * 2));
+      const b = Math.round(34 + (34 - 34) * (ratio * 2));
+      return `rgb(${r}, ${g}, ${b})`;
+    } else {
+      const r = Math.round(235 + (239 - 235) * ((ratio - 0.5) * 2));
+      const g = Math.round(173 - 173 * ((ratio - 0.5) * 2));
+      const b = Math.round(34 + (68 - 34) * ((ratio - 0.5) * 2));
+      return `rgb(${r}, ${g}, ${b})`;
+    }
+  };
+
+  const getValue = (x, y) => {
+    const item = data.find(d => d.x === x && d.y === y);
+    return item ? item.value : 0;
+  };
+
+  const cellStyle = {
+    width: '60px',
+    height: '40px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    fontSize: '12px',
+    fontWeight: 500,
+    border: '1px solid #e5e7eb',
+  };
+
+  return (
+    <div style={{ padding: '16px' }}>
+      {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+      <div style={{ overflowX: 'auto' }}>
+        <table style={{ borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={{ ...cellStyle, background: '#f9fafb' }}></th>
+              {xLabels.map(x => (
+                <th key={x} style={{ ...cellStyle, background: '#f9fafb' }}>{x}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {yLabels.map(y => (
+              <tr key={y}>
+                <td style={{ ...cellStyle, background: '#f9fafb', fontWeight: 600 }}>{y}</td>
+                {xLabels.map(x => {
+                  const value = getValue(x, y);
+                  return (
+                    <td
+                      key={x}
+                      style={{ ...cellStyle, background: getColor(value), color: '#fff' }}
+                    >
+                      {value.toFixed(1)}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/KpiCard.jsx
+++ b/frontend/src/Components/kpi/KpiCard.jsx
@@ -1,0 +1,64 @@
+export default function KpiCard({ title, loading = false, error = null, children, className = '' }) {
+  const cardStyle = {
+    background: '#fff',
+    borderRadius: '8px',
+    boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+    overflow: 'hidden',
+  };
+
+  const headerStyle = {
+    padding: '16px',
+    borderBottom: '1px solid #e5e7eb',
+    fontSize: '16px',
+    fontWeight: 600,
+    color: '#1f2937',
+  };
+
+  const bodyStyle = {
+    padding: '16px',
+    minHeight: '200px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  const spinnerStyle = {
+    width: '40px',
+    height: '40px',
+    border: '4px solid #e5e7eb',
+    borderTopColor: '#3b82f6',
+    borderRadius: '50%',
+    animation: 'spin 1s linear infinite',
+  };
+
+  const errorStyle = {
+    color: '#ef4444',
+    fontSize: '14px',
+    textAlign: 'center',
+  };
+
+  const emptyStyle = {
+    color: '#9ca3af',
+    fontSize: '14px',
+    textAlign: 'center',
+  };
+
+  return (
+    <div className={`kpi-card ${className}`} style={cardStyle}>
+      {title && <div style={headerStyle}>{title}</div>}
+      <div style={bodyStyle}>
+        {loading && (
+          <div style={spinnerStyle}></div>
+        )}
+        {error && (
+          <div style={errorStyle}>Error: {error}</div>
+        )}
+        {!loading && !error && !children && (
+          <div style={emptyStyle}>Sin datos</div>
+        )}
+        {!loading && !error && children && children}
+      </div>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/KpiCard.test.jsx
+++ b/frontend/src/Components/kpi/KpiCard.test.jsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import KpiCard from './KpiCard';
+
+describe('KpiCard', () => {
+  describe('Rendering', () => {
+    it('renders title when provided', () => {
+      render(<KpiCard title="Test Title" />);
+      expect(screen.getByText('Test Title')).toBeInTheDocument();
+    });
+
+    it('renders children when data is present', () => {
+      render(
+        <KpiCard title="Test Card">
+          <span>Chart Data</span>
+        </KpiCard>
+      );
+      expect(screen.getByText('Chart Data')).toBeInTheDocument();
+    });
+
+    it('renders loading state when loading prop is true', () => {
+      render(<KpiCard title="Loading Card" loading={true} />);
+      // Loading state shows a spinner div with animation
+      const spinner = document.querySelector('div[style*="animation"]');
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it('renders error state when error prop is provided', () => {
+      render(<KpiCard title="Error Card" error="Something went wrong" />);
+      expect(screen.getByText('Error: Something went wrong')).toBeInTheDocument();
+    });
+
+    it('renders empty state when no children and not loading and no error', () => {
+      render(<KpiCard title="Empty Card" />);
+      expect(screen.getByText('Sin datos')).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/Components/kpi/KpiNumberCard.jsx
+++ b/frontend/src/Components/kpi/KpiNumberCard.jsx
@@ -1,0 +1,20 @@
+export default function KpiNumberCard({ label, value, unit = '', title }) {
+  const displayValue = typeof value === 'number' ? value.toFixed(2) : '—';
+
+  return (
+    <div style={{
+      padding: '24px',
+      background: '#fff',
+      borderRadius: '8px',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+      textAlign: 'center',
+    }}>
+      {title && <h3 style={{ margin: '0 0 12px 0', fontSize: '14px', fontWeight: 500', color: '#6b7280' }}>{title}</h3>}
+      <div style={{ fontSize: '48px', fontWeight: 700, color: '#1f2937', lineHeight: 1 }}>
+        {displayValue}
+        {unit && <span style={{ fontSize: '24px', fontWeight: 500, color: '#6b7280' }}>{unit}</span>}
+      </div>
+      {label && <div style={{ marginTop: '8px', fontSize: '14px', color: '#6b7280' }}>{label}</div>}
+    </div>
+  );
+}

--- a/frontend/src/Components/kpi/LineChartKpi.jsx
+++ b/frontend/src/Components/kpi/LineChartKpi.jsx
@@ -1,0 +1,33 @@
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+
+const SERIES_COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+
+export default function LineChartKpi({ series = [], title, showDots = true }) {
+  const chartStyle = { margin: { top: 5, right: 30, left: 20, bottom: 5 } };
+
+  return (
+    <div style={{ padding: '16px' }}>
+      {title && <h3 style={{ margin: '0 0 16px 0', fontSize: '16px', fontWeight: 600 }}>{title}</h3>}
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={series[0]?.data || []} margin={chartStyle}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="x" />
+          <YAxis />
+          <Tooltip />
+          <Legend />
+          {series.map((s, index) => (
+            <Line
+              key={s.name}
+              name={s.name}
+              data={s.data}
+              dataKey="y"
+              stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
+              dot={showDots}
+              connectNulls
+            />
+          ))}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/frontend/src/api/kpi.js
+++ b/frontend/src/api/kpi.js
@@ -1,0 +1,157 @@
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+/**
+ * Build query string from filters object.
+ * @param {object} filters - Key-value pairs for query params
+ * @returns {string} Query string including leading '?'
+ */
+function buildQueryString(filters = {}) {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      params.append(key, value);
+    }
+  });
+  const qs = params.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/**
+ * Fetch KPI data from a specific endpoint.
+ * @param {string} endpoint - KPI endpoint name (e.g. 'aql-by-style/')
+ * @param {object} filters - Optional filters to apply
+ * @returns {Promise<any>} JSON response data
+ */
+export async function fetchKpi(endpoint, filters = {}) {
+  const queryString = buildQueryString(filters);
+  const url = `${API_BASE}/quality/kpis/${endpoint}${queryString}`;
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: response.statusText }));
+    throw new Error(error.error || `KPI fetch failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+
+// ─── Individual KPI helpers ──────────────────────────────────────────────────
+
+/** AQL grouped by style (defects/sample % per style). */
+export async function getAqlByStyle(filters) {
+  return fetchKpi('aql-by-style/', filters);
+}
+
+/** AQL trend by week — useful for control charts. */
+export async function getAqlWeekly(filters) {
+  return fetchKpi('aql-weekly/', filters);
+}
+
+/** Total audited pieces per week. */
+export async function getAuditedPieces(filters) {
+  return fetchKpi('audited-pieces/', filters);
+}
+
+/** Acceptance / Rejection rate per production line (team). */
+export async function getAcReRateByLine(filters) {
+  return fetchKpi('ac-re-rate-by-line/', filters);
+}
+
+/** Seconds spent on rework per inspection — requires capture data. */
+export async function getSecondsRework(filters) {
+  return fetchKpi('seconds-rework/', filters);
+}
+
+/** Performance (% accepted) grouped by customer. */
+export async function getPerformanceByCustomer(filters) {
+  return fetchKpi('performance-by-customer/', filters);
+}
+
+/** Performance (% accepted) grouped by production line (team). */
+export async function getPerformanceByLine(filters) {
+  return fetchKpi('performance-by-line/', filters);
+}
+
+/** Top defect types by frequency — requires capture defect types. */
+export async function getTopDefects(filters) {
+  return fetchKpi('top-defects/', filters);
+}
+
+/** Fabric defect distribution — requires fabric inspection data. */
+export async function getFabricDefects(filters) {
+  return fetchKpi('fabric-defects/', filters);
+}
+
+/** Defect breakdown by style type — requires capture defect types. */
+export async function getDefectsByStyleType(filters) {
+  return fetchKpi('defects-by-style-type/', filters);
+}
+
+/** Pass vs. reject count distribution across all inspections. */
+export async function getPassRejectDistribution(filters) {
+  return fetchKpi('pass-reject-distribution/', filters);
+}
+
+/** Rejected pieces evolution over weeks. */
+export async function getRejectedEvolution(filters) {
+  return fetchKpi('rejected-evolution/', filters);
+}
+
+/** Container inspection status counts. */
+export async function getContainersByState(filters) {
+  return fetchKpi('containers-by-state/', filters);
+}
+
+/** Overall defect rate (defects per 100 units inspected). */
+export async function getDefectRate(filters) {
+  return fetchKpi('defect-rate/', filters);
+}
+
+// ─── Bulk fetch ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all 14 KPIs in parallel, gracefully handling partial failures.
+ * Returns an object keyed by KPI name.
+ *
+ * @param {object} filters - Optional shared filters for all KPIs
+ * @returns {Promise<object>} { aqlByStyle, aqlWeekly, auditedPieces, ... }
+ */
+export async function fetchAllKpis(filters = {}) {
+  const kpiMap = {
+    aqlByStyle: getAqlByStyle,
+    aqlWeekly: getAqlWeekly,
+    auditedPieces: getAuditedPieces,
+    acReRateByLine: getAcReRateByLine,
+    secondsRework: getSecondsRework,
+    performanceByCustomer: getPerformanceByCustomer,
+    performanceByLine: getPerformanceByLine,
+    topDefects: getTopDefects,
+    fabricDefects: getFabricDefects,
+    defectsByStyleType: getDefectsByStyleType,
+    passRejectDistribution: getPassRejectDistribution,
+    rejectedEvolution: getRejectedEvolution,
+    containersByState: getContainersByState,
+    defectRate: getDefectRate,
+  };
+
+  const entries = Object.entries(kpiMap).map(([key, fn]) => [
+    key,
+    fn(filters).catch((err) => ({ error: err.message })),
+  ]);
+
+  const results = await Promise.allSettled(entries.map(([, p]) => p));
+
+  /** @type {object} */
+  const kpis = {};
+  entries.forEach(([key], i) => {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      kpis[key] = result.value;
+    } else {
+      kpis[key] = { error: result.reason?.message ?? 'Unknown error' };
+    }
+  });
+
+  return kpis;
+}

--- a/frontend/src/utils/kpiCalculations.js
+++ b/frontend/src/utils/kpiCalculations.js
@@ -1,0 +1,321 @@
+/**
+ * KPI calculation utilities — pure functions for in-memory Excel data.
+ *
+ * All functions receive the raw parsed Excel row array and return a
+ * processed result suitable for charting / display.
+ *
+ * KPIs unavailable in volatile (Excel-only) mode return null so the UI
+ * can render a graceful "No disponible en modo rápido" message.
+ */
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Sum a numeric field, ignoring null / undefined / non-numeric values.
+ * @param {object[]} rows
+ * @param {string} field
+ * @returns {number}
+ */
+function sumField(rows, field) {
+  return rows.reduce((acc, row) => {
+    const val = Number(row[field]);
+    return acc + (isNaN(val) ? 0 : val);
+  }, 0);
+}
+
+/**
+ * Group rows by a string field and aggregate a numeric field.
+ * @param {object[]} rows
+ * @param {string} groupKey - Field to group by
+ * @param {string} aggField - Numeric field to sum
+ * @returns {{ name: string, value: number }[]}
+ */
+function groupBySum(rows, groupKey, aggField) {
+  const map = {};
+  for (const row of rows) {
+    const key = String(row[groupKey] ?? 'Desconocido');
+    map[key] = (map[key] ?? 0) + (Number(row[aggField]) || 0);
+  }
+  return Object.entries(map)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+/**
+ * Group rows by a string field and compute an average of a numeric field.
+ * @param {object[]} rows
+ * @param {string} groupKey
+ * @param {string} aggField
+ * @returns {{ name: string, value: number }[]}
+ */
+function groupByAvg(rows, groupKey, aggField) {
+  const map = {};
+  const counts = {};
+  for (const row of rows) {
+    const key = String(row[groupKey] ?? 'Desconocido');
+    const val = Number(row[aggField]) || 0;
+    map[key] = (map[key] ?? 0) + val;
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return Object.entries(map).map(([name, total]) => ({
+    name,
+    value: counts[name] > 0 ? total / counts[name] : 0,
+  }));
+}
+
+/**
+ * Group by field and return count of rows.
+ * @param {object[]} rows
+ * @param {string} groupKey
+ * @returns {{ name: string, value: number }[]}
+ */
+function groupByCount(rows, groupKey) {
+  const map = {};
+  for (const row of rows) {
+    const key = String(row[groupKey] ?? 'Desconocido');
+    map[key] = (map[key] ?? 0) + 1;
+  }
+  return Object.entries(map)
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+}
+
+// ─── KPI calculations ────────────────────────────────────────────────────────
+
+/**
+ * AQL by style: total defects / total sample * 100 per style.
+ *
+ * @param {object[]} rows - Parsed Excel rows
+ * @returns {{ style: string, aql: number }[]}
+ */
+export function calculateAqlByStyle(rows) {
+  const map = {};
+  for (const row of rows) {
+    const style = String(row.style ?? 'Desconocido');
+    const defects = Number(row.defects_total) || 0;
+    const sample = Number(row.sample) || 0;
+    if (!map[style]) map[style] = { defects: 0, sample: 0 };
+    map[style].defects += defects;
+    map[style].sample += sample;
+  }
+  return Object.entries(map).map(([style, { defects, sample }]) => ({
+    style,
+    aql: sample > 0 ? (defects / sample) * 100 : 0,
+  }));
+}
+
+/**
+ * AQL weekly: total defects / total sample * 100 per week.
+ *
+ * @param {object[]} rows
+ * @returns {{ week: string, aql: number }[]}
+ */
+export function calculateAqlWeekly(rows) {
+  const map = {};
+  for (const row of rows) {
+    const week = String(row.week ?? 'N/A');
+    const defects = Number(row.defects_total) || 0;
+    const sample = Number(row.sample) || 0;
+    if (!map[week]) map[week] = { defects: 0, sample: 0 };
+    map[week].defects += defects;
+    map[week].sample += sample;
+  }
+  return Object.entries(map)
+    .map(([week, { defects, sample }]) => ({
+      week,
+      aql: sample > 0 ? (defects / sample) * 100 : 0,
+    }))
+    .sort((a, b) => a.week.localeCompare(b.week, undefined, { numeric: true }));
+}
+
+/**
+ * Total audited pieces per week (sum of the `sample` field).
+ *
+ * @param {object[]} rows
+ * @returns {{ week: string, pieces: number }[]}
+ */
+export function calculateAuditedPieces(rows) {
+  const map = {};
+  for (const row of rows) {
+    const week = String(row.week ?? 'N/A');
+    const sample = Number(row.sample) || 0;
+    map[week] = (map[week] ?? 0) + sample;
+  }
+  return Object.entries(map)
+    .map(([week, pieces]) => ({ week, pieces }))
+    .sort((a, b) => a.week.localeCompare(b.week, undefined, { numeric: true }));
+}
+
+/**
+ * Acceptance / Rejection rate per production line (team field).
+ * Returns pass rate = accepted / (accepted + rejected) * 100.
+ *
+ * @param {object[]} rows
+ * @returns {{ line: string, passRate: number, accepted: number, rejected: number }[]}
+ */
+export function calculateAcReRateByLine(rows) {
+  const map = {};
+  for (const row of rows) {
+    const line = String(row.team ?? 'Desconocida');
+    const accepted = Number(row.accepted) || 0;
+    const rejected = Number(row.rejected) || 0;
+    if (!map[line]) map[line] = { accepted: 0, rejected: 0 };
+    map[line].accepted += accepted;
+    map[line].rejected += rejected;
+  }
+  return Object.entries(map).map(([line, { accepted, rejected }]) => {
+    const total = accepted + rejected;
+    return {
+      line,
+      passRate: total > 0 ? (accepted / total) * 100 : 0,
+      accepted,
+      rejected,
+    };
+  });
+}
+
+/**
+ * Seconds rework — NOT available in Excel volatile mode.
+ *
+ * @param {object[]} _rows
+ * @returns {null}
+ */
+export function calculateSecondsRework(_rows) {
+  return null;
+}
+
+/**
+ * Performance by customer: accepted / sample * 100 per customer.
+ *
+ * @param {object[]} rows
+ * @returns {{ customer: string, performance: number }[]}
+ */
+export function calculatePerformanceByCustomer(rows) {
+  const map = {};
+  for (const row of rows) {
+    const customer = String(row.customer ?? 'Desconocido');
+    const accepted = Number(row.accepted) || 0;
+    const sample = Number(row.sample) || 0;
+    if (!map[customer]) map[customer] = { accepted: 0, sample: 0 };
+    map[customer].accepted += accepted;
+    map[customer].sample += sample;
+  }
+  return Object.entries(map).map(([customer, { accepted, sample }]) => ({
+    customer,
+    performance: sample > 0 ? (accepted / sample) * 100 : 0,
+  }));
+}
+
+/**
+ * Performance by production line (team): accepted / sample * 100 per line.
+ *
+ * @param {object[]} rows
+ * @returns {{ line: string, performance: number }[]}
+ */
+export function calculatePerformanceByLine(rows) {
+  const map = {};
+  for (const row of rows) {
+    const line = String(row.team ?? 'Desconocida');
+    const accepted = Number(row.accepted) || 0;
+    const sample = Number(row.sample) || 0;
+    if (!map[line]) map[line] = { accepted: 0, sample: 0 };
+    map[line].accepted += accepted;
+    map[line].sample += sample;
+  }
+  return Object.entries(map).map(([line, { accepted, sample }]) => ({
+    line,
+    performance: sample > 0 ? (accepted / sample) * 100 : 0,
+  }));
+}
+
+/**
+ * Top defects: uses defects_total as a single metric since Excel
+ * does not contain individual defect type breakdowns.
+ *
+ * @param {object[]} rows
+ * @returns {{ defectType: string, count: number }[]}
+ */
+export function calculateTopDefects(rows) {
+  // Single aggregated "Total Defects" bucket
+  const total = sumField(rows, 'defects_total');
+  return [{ defectType: 'Total Defectos', count: total }];
+}
+
+/**
+ * Fabric defects — NOT available in Excel volatile mode.
+ *
+ * @param {object[]} _rows
+ * @returns {null}
+ */
+export function calculateFabricDefects(_rows) {
+  return null;
+}
+
+/**
+ * Defects by style type — NOT available in Excel volatile mode.
+ *
+ * @param {object[]} _rows
+ * @returns {null}
+ */
+export function calculateDefectsByStyleType(_rows) {
+  return null;
+}
+
+/**
+ * Pass / reject distribution: count of rows with pass_or_fail = 'PASS' vs 'REJECT'.
+ *
+ * @param {object[]} rows
+ * @returns {{ result: string, count: number }[]}
+ */
+export function calculatePassRejectDistribution(rows) {
+  return groupByCount(rows, 'pass_or_fail');
+}
+
+/**
+ * Rejected pieces evolution per week.
+ *
+ * @param {object[]} rows
+ * @returns {{ week: string, rejected: number }[]}
+ */
+export function calculateRejectedEvolution(rows) {
+  const map = {};
+  for (const row of rows) {
+    const week = String(row.week ?? 'N/A');
+    const rejected = Number(row.rejected) || 0;
+    map[week] = (map[week] ?? 0) + rejected;
+  }
+  return Object.entries(map)
+    .map(([week, rejected]) => ({ week, rejected }))
+    .sort((a, b) => a.week.localeCompare(b.week, undefined, { numeric: true }));
+}
+
+/**
+ * Containers by state — NOT available in Excel volatile mode.
+ *
+ * @param {object[]} _rows
+ * @returns {null}
+ */
+export function calculateContainersByState(_rows) {
+  return null;
+}
+
+/**
+ * Overall defect rate: SUM(defects_total) / SUM(sample) * 100 across all rows.
+ * Rows with zero sample are excluded from the sum to avoid Infinity.
+ *
+ * @param {object[]} rows
+ * @returns {number}
+ */
+export function calculateDefectRate(rows) {
+  let totalDefects = 0;
+  let totalSample = 0;
+  for (const row of rows) {
+    const defects = Number(row.defects_total) || 0;
+    const sample = Number(row.sample) || 0;
+    if (sample > 0) {
+      totalDefects += defects;
+      totalSample += sample;
+    }
+  }
+  return totalSample > 0 ? (totalDefects / totalSample) * 100 : 0;
+}

--- a/frontend/src/utils/kpiCalculations.test.js
+++ b/frontend/src/utils/kpiCalculations.test.js
@@ -1,0 +1,283 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateAqlByStyle,
+  calculateAqlWeekly,
+  calculateAuditedPieces,
+  calculateAcReRateByLine,
+  calculateSecondsRework,
+  calculatePerformanceByCustomer,
+  calculatePerformanceByLine,
+  calculateTopDefects,
+  calculateFabricDefects,
+  calculateDefectsByStyleType,
+  calculatePassRejectDistribution,
+  calculateRejectedEvolution,
+  calculateContainersByState,
+  calculateDefectRate,
+} from './kpiCalculations.js';
+
+// ─── Shared test fixtures ─────────────────────────────────────────────────────
+
+/** Minimal valid row set covering all used fields. */
+const SAMPLE_ROWS = [
+  {
+    week: '1',
+    team: 'Linea A',
+    style: 'Style-X',
+    customer: 'Cliente-1',
+    color: 'Rojo',
+    qty: 100,
+    accepted: 90,
+    rejected: 10,
+    sample: 100,
+    defects_total: 12,
+    pass_or_fail: 'PASS',
+    date_1: '2026-01-01',
+  },
+  {
+    week: '1',
+    team: 'Linea A',
+    style: 'Style-X',
+    customer: 'Cliente-1',
+    color: 'Azul',
+    qty: 50,
+    accepted: 45,
+    rejected: 5,
+    sample: 50,
+    defects_total: 5,
+    pass_or_fail: 'PASS',
+    date_1: '2026-01-02',
+  },
+  {
+    week: '2',
+    team: 'Linea B',
+    style: 'Style-Y',
+    customer: 'Cliente-2',
+    color: 'Verde',
+    qty: 80,
+    accepted: 60,
+    rejected: 20,
+    sample: 80,
+    defects_total: 20,
+    pass_or_fail: 'REJECT',
+    date_1: '2026-01-09',
+  },
+  {
+    week: '2',
+    team: 'Linea B',
+    style: 'Style-Y',
+    customer: 'Cliente-2',
+    color: 'Amarillo',
+    qty: 40,
+    accepted: 38,
+    rejected: 2,
+    sample: 40,
+    defects_total: 2,
+    pass_or_fail: 'PASS',
+    date_1: '2026-01-10',
+  },
+  {
+    week: '2',
+    team: 'Linea A',
+    style: 'Style-X',
+    customer: 'Cliente-1',
+    color: 'Rojo',
+    qty: 60,
+    accepted: 50,
+    rejected: 10,
+    sample: 60,
+    defects_total: 10,
+    pass_or_fail: 'REJECT',
+    date_1: '2026-01-11',
+  },
+];
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('calculateAqlByStyle', () => {
+  it('computes defects/sample*100 grouped by style', () => {
+    const result = calculateAqlByStyle(SAMPLE_ROWS);
+    const styleX = result.find((r) => r.style === 'Style-X');
+    expect(styleX).toBeDefined();
+    // Style-X: (12+5+10) / (100+50+60)*100 = 27/210*100 ≈ 12.857
+    expect(styleX.aql).toBeCloseTo(12.857, 2);
+  });
+
+  it('handles empty array', () => {
+    expect(calculateAqlByStyle([])).toEqual([]);
+  });
+
+  it('handles missing fields gracefully', () => {
+    const result = calculateAqlByStyle([{ style: 'S1' }]);
+    expect(result).toHaveLength(1);
+    expect(result[0].aql).toBe(0);
+  });
+});
+
+describe('calculateAqlWeekly', () => {
+  it('computes weekly AQL sorted by week', () => {
+    const result = calculateAqlWeekly(SAMPLE_ROWS);
+    expect(result).toHaveLength(2);
+    expect(result[0].week).toBe('1');
+    // Week 1: (12+5)/(100+50)*100 = 17/150*100 ≈ 11.333
+    expect(result[0].aql).toBeCloseTo(11.333, 2);
+    // Week 2: (20+2+10)/(80+40+60)*100 = 32/180*100 ≈ 17.778
+    expect(result[1].aql).toBeCloseTo(17.778, 2);
+  });
+
+  it('handles empty array', () => {
+    expect(calculateAqlWeekly([])).toEqual([]);
+  });
+});
+
+describe('calculateAuditedPieces', () => {
+  it('sums sample field per week', () => {
+    const result = calculateAuditedPieces(SAMPLE_ROWS);
+    const w1 = result.find((r) => r.week === '1');
+    const w2 = result.find((r) => r.week === '2');
+    expect(w1.pieces).toBe(150);   // 100 + 50
+    expect(w2.pieces).toBe(180);  // 80 + 40 + 60
+  });
+
+  it('handles empty array', () => {
+    expect(calculateAuditedPieces([])).toEqual([]);
+  });
+});
+
+describe('calculateAcReRateByLine', () => {
+  it('computes pass rate per team', () => {
+    const result = calculateAcReRateByLine(SAMPLE_ROWS);
+    const lineaA = result.find((r) => r.line === 'Linea A');
+    expect(lineaA).toBeDefined();
+    // Linea A: accepted=90+45+50=185, rejected=10+5+10=25, total=210
+    // passRate = 185/210*100 ≈ 88.095
+    expect(lineaA.passRate).toBeCloseTo(88.095, 2);
+    expect(lineaA.accepted).toBe(185);
+    expect(lineaA.rejected).toBe(25);
+  });
+
+  it('handles empty array', () => {
+    expect(calculateAcReRateByLine([])).toEqual([]);
+  });
+});
+
+describe('calculateSecondsRework', () => {
+  it('returns null (not available in Excel volatile mode)', () => {
+    expect(calculateSecondsRework(SAMPLE_ROWS)).toBeNull();
+    expect(calculateSecondsRework([])).toBeNull();
+  });
+});
+
+describe('calculatePerformanceByCustomer', () => {
+  it('computes accepted/sample*100 per customer', () => {
+    const result = calculatePerformanceByCustomer(SAMPLE_ROWS);
+    const c1 = result.find((r) => r.customer === 'Cliente-1');
+    const c2 = result.find((r) => r.customer === 'Cliente-2');
+    // Cliente-1: accepted=90+45+50=185, sample=100+50+60=210 → 88.095
+    expect(c1.performance).toBeCloseTo(88.095, 2);
+    // Cliente-2: accepted=60+38=98, sample=80+40=120 → 81.667
+    expect(c2.performance).toBeCloseTo(81.667, 2);
+  });
+
+  it('handles empty array', () => {
+    expect(calculatePerformanceByCustomer([])).toEqual([]);
+  });
+});
+
+describe('calculatePerformanceByLine', () => {
+  it('computes accepted/sample*100 per team', () => {
+    const result = calculatePerformanceByLine(SAMPLE_ROWS);
+    const lineaB = result.find((r) => r.line === 'Linea B');
+    expect(lineaB).toBeDefined();
+    // Linea B: accepted=60+38=98, sample=80+40=120 → 81.667
+    expect(lineaB.performance).toBeCloseTo(81.667, 2);
+  });
+
+  it('handles empty array', () => {
+    expect(calculatePerformanceByLine([])).toEqual([]);
+  });
+});
+
+describe('calculateTopDefects', () => {
+  it('returns single Total Defectos bucket with sum of defects_total', () => {
+    const result = calculateTopDefects(SAMPLE_ROWS);
+    expect(result).toHaveLength(1);
+    expect(result[0].defectType).toBe('Total Defectos');
+    // 12 + 5 + 20 + 2 + 10 = 49
+    expect(result[0].count).toBe(49);
+  });
+
+  it('handles empty array', () => {
+    const result = calculateTopDefects([]);
+    expect(result).toHaveLength(1);
+    expect(result[0].count).toBe(0);
+  });
+});
+
+describe('calculateFabricDefects', () => {
+  it('returns null (not available in Excel volatile mode)', () => {
+    expect(calculateFabricDefects(SAMPLE_ROWS)).toBeNull();
+    expect(calculateFabricDefects([])).toBeNull();
+  });
+});
+
+describe('calculateDefectsByStyleType', () => {
+  it('returns null (not available in Excel volatile mode)', () => {
+    expect(calculateDefectsByStyleType(SAMPLE_ROWS)).toBeNull();
+    expect(calculateDefectsByStyleType([])).toBeNull();
+  });
+});
+
+describe('calculatePassRejectDistribution', () => {
+  it('counts PASS vs REJECT rows', () => {
+    const result = calculatePassRejectDistribution(SAMPLE_ROWS);
+    const pass = result.find((r) => r.name === 'PASS');
+    const reject = result.find((r) => r.name === 'REJECT');
+    expect(pass.value).toBe(3);   // 3 PASS rows
+    expect(reject.value).toBe(2); // 2 REJECT rows
+  });
+
+  it('handles empty array', () => {
+    expect(calculatePassRejectDistribution([])).toEqual([]);
+  });
+});
+
+describe('calculateRejectedEvolution', () => {
+  it('sums rejected per week', () => {
+    const result = calculateRejectedEvolution(SAMPLE_ROWS);
+    const w1 = result.find((r) => r.week === '1');
+    const w2 = result.find((r) => r.week === '2');
+    expect(w1.rejected).toBe(15);  // 10 + 5
+    expect(w2.rejected).toBe(32);  // 20 + 2 + 10
+  });
+
+  it('handles empty array', () => {
+    expect(calculateRejectedEvolution([])).toEqual([]);
+  });
+});
+
+describe('calculateContainersByState', () => {
+  it('returns null (not available in Excel volatile mode)', () => {
+    expect(calculateContainersByState(SAMPLE_ROWS)).toBeNull();
+    expect(calculateContainersByState([])).toBeNull();
+  });
+});
+
+describe('calculateDefectRate', () => {
+  it('computes total defects / total sample * 100', () => {
+    const result = calculateDefectRate(SAMPLE_ROWS);
+    // Total defects = 12+5+20+2+10 = 49
+    // Total sample  = 100+50+80+40+60 = 330
+    // Defect rate = 49/330*100 ≈ 14.8485
+    expect(result).toBeCloseTo(14.8485, 2);
+  });
+
+  it('handles empty array', () => {
+    expect(calculateDefectRate([])).toBe(0);
+  });
+
+  it('skips rows with zero sample', () => {
+    const result = calculateDefectRate([{ defects_total: 5, sample: 0 }]);
+    expect(result).toBe(0);
+  });
+});

--- a/frontend/src/views/DashboardView.css
+++ b/frontend/src/views/DashboardView.css
@@ -1,0 +1,82 @@
+.dashboard-view {
+  padding: 24px;
+  background-color: #f9fafb;
+  min-height: 100vh;
+}
+
+.dashboard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.dashboard-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0;
+}
+
+.refresh-btn {
+  padding: 10px 20px;
+  background-color: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background-color: #2563eb;
+}
+
+.refresh-btn:disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+  gap: 16px;
+}
+
+.full-width {
+  grid-column: 1 / -1;
+}
+
+.null-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 200px;
+  color: #9ca3af;
+  font-size: 14px;
+  text-align: center;
+}
+
+/* Responsive: single column on mobile */
+@media (max-width: 768px) {
+  .dashboard-view {
+    padding: 16px;
+  }
+
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .dashboard-title {
+    font-size: 22px;
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/views/DashboardView.jsx
+++ b/frontend/src/views/DashboardView.jsx
@@ -1,0 +1,448 @@
+import { useState, useEffect, useCallback } from 'react';
+import { fetchAllKpis } from '../api/kpi';
+import * as calc from '../utils/kpiCalculations';
+import KpiCard from '../Components/kpi/KpiCard';
+import BarChartKpi from '../Components/kpi/BarChartKpi';
+import LineChartKpi from '../Components/kpi/LineChartKpi';
+import DonutChartKpi from '../Components/kpi/DonutChartKpi';
+import HeatmapKpi from '../Components/kpi/HeatmapKpi';
+import KpiNumberCard from '../Components/kpi/KpiNumberCard';
+import FilterBar from '../Components/kpi/FilterBar';
+import './DashboardView.css';
+
+/**
+ * Calculate all KPIs from volatile (Excel) data.
+ * Returns null for KPIs not available in volatile mode.
+ * @param {object[]} rows - Parsed Excel rows
+ * @returns {object} KPI results object
+ */
+function calculateAllKpis(rows) {
+  if (!rows || rows.length === 0) {
+    return {
+      aqlByStyle: null,
+      aqlWeekly: null,
+      auditedPieces: null,
+      acReRateByLine: null,
+      secondsRework: null,
+      performanceByCustomer: null,
+      performanceByLine: null,
+      topDefects: null,
+      fabricDefects: null,
+      defectsByStyleType: null,
+      passRejectDistribution: null,
+      rejectedEvolution: null,
+      containersByState: null,
+      defectRate: null,
+    };
+  }
+
+  return {
+    aqlByStyle: calc.calculateAqlByStyle(rows),
+    aqlWeekly: calc.calculateAqlWeekly(rows),
+    auditedPieces: calc.calculateAuditedPieces(rows),
+    acReRateByLine: calc.calculateAcReRateByLine(rows),
+    secondsRework: calc.calculateSecondsRework(rows),
+    performanceByCustomer: calc.calculatePerformanceByCustomer(rows),
+    performanceByLine: calc.calculatePerformanceByLine(rows),
+    topDefects: calc.calculateTopDefects(rows),
+    fabricDefects: calc.calculateFabricDefects(rows),
+    defectsByStyleType: calc.calculateDefectsByStyleType(rows),
+    passRejectDistribution: calc.calculatePassRejectDistribution(rows),
+    rejectedEvolution: calc.calculateRejectedEvolution(rows),
+    containersByState: calc.calculateContainersByState(rows),
+    defectRate: calc.calculateDefectRate(rows),
+  };
+}
+
+/**
+ * Transform API response to chart-friendly format.
+ * Handles both direct data and wrapped response formats.
+ */
+function normalizeApiData(kpiName, data) {
+  if (!data || data.error) return null;
+  return data;
+}
+
+/**
+ * Transform pass/reject distribution for DonutChart.
+ */
+function transformPassReject(data) {
+  if (!data || data.error) return null;
+  return (data.result || data).map(item => ({
+    name: item.name || item.result,
+    value: item.value || item.count,
+  }));
+}
+
+/**
+ * Transform AQL by style for BarChart horizontal.
+ */
+function transformAqlByStyle(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.style,
+    value: parseFloat(item.aql.toFixed(2)),
+  }));
+}
+
+/**
+ * Transform AQL weekly for LineChart.
+ */
+function transformAqlWeekly(data) {
+  if (!data || data.error) return null;
+  return [{
+    name: 'AQL Semanal',
+    data: (data).map(item => ({
+      x: item.week,
+      y: parseFloat(item.aql.toFixed(2)),
+    })),
+  }];
+}
+
+/**
+ * Transform audited pieces for LineChart.
+ */
+function transformAuditedPieces(data) {
+  if (!data || data.error) return null;
+  return [{
+    name: 'Piezas Auditadas',
+    data: (data).map(item => ({
+      x: item.week,
+      y: item.pieces,
+    })),
+  }];
+}
+
+/**
+ * Transform rejected evolution for LineChart.
+ */
+function transformRejectedEvolution(data) {
+  if (!data || data.error) return null;
+  return [{
+    name: 'Rechazadas',
+    data: (data).map(item => ({
+      x: item.week,
+      y: item.rejected,
+    })),
+  }];
+}
+
+/**
+ * Transform AC/RE rate by line for stacked BarChart.
+ */
+function transformAcReRateByLine(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.line,
+    accepted: item.accepted,
+    rejected: item.rejected,
+  }));
+}
+
+/**
+ * Transform performance by customer for BarChart.
+ */
+function transformPerformanceByCustomer(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.customer,
+    value: parseFloat(item.performance.toFixed(2)),
+  }));
+}
+
+/**
+ * Transform performance by line for horizontal BarChart.
+ */
+function transformPerformanceByLine(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.line,
+    value: parseFloat(item.performance.toFixed(2)),
+  }));
+}
+
+/**
+ * Transform top defects for horizontal BarChart.
+ */
+function transformTopDefects(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.defectType,
+    value: item.count,
+  }));
+}
+
+/**
+ * Transform fabric defects for BarChart.
+ */
+function transformFabricDefects(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    label: item.defectType,
+    value: item.count,
+  }));
+}
+
+/**
+ * Transform containers by state for DonutChart.
+ */
+function transformContainersByState(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    name: item.state || item.status,
+    value: item.count,
+  }));
+}
+
+/**
+ * Transform defects by style × type for Heatmap.
+ */
+function transformDefectsByStyleType(data) {
+  if (!data || data.error) return null;
+  return (data).map(item => ({
+    x: item.style,
+    y: item.defectType,
+    value: item.count,
+  }));
+}
+
+/**
+ * Transform seconds rework for double LineChart.
+ */
+function transformSecondsRework(data) {
+  if (!data || data.error) return null;
+  return [{
+    name: 'Tiempo Rework',
+    data: (data).map(item => ({
+      x: item.week || item.period,
+      y: item.seconds,
+    })),
+  }];
+}
+
+export default function DashboardView({ volatileData }) {
+  const isLiveMode = !volatileData;
+
+  const [filters, setFilters] = useState({
+    date_range: ['', ''],
+    week: '',
+    team: '',
+    style: '',
+    color: '',
+    customer: '',
+    batch: '',
+  });
+
+  const [kpiData, setKpiData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      if (isLiveMode) {
+        const result = await fetchAllKpis(filters);
+        setKpiData(result);
+      } else {
+        const result = calculateAllKpis(volatileData);
+        setKpiData(result);
+      }
+    } catch (err) {
+      setError(err.message || 'Error al cargar datos');
+    } finally {
+      setLoading(false);
+    }
+  }, [isLiveMode, filters, volatileData]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleFilterChange = useCallback((newFilters) => {
+    setFilters(newFilters);
+  }, []);
+
+  const handleApply = useCallback(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleReset = useCallback(() => {
+    setFilters({
+      date_range: ['', ''],
+      week: '',
+      team: '',
+      style: '',
+      color: '',
+      customer: '',
+      batch: '',
+    });
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    loadData();
+  }, [loadData]);
+
+  // Transform data for charts
+  const defectRate = kpiData?.defectRate;
+  const passRejectData = transformPassReject(kpiData?.passRejectDistribution);
+  const aqlWeeklySeries = transformAqlWeekly(kpiData?.aqlWeekly);
+  const aqlByStyleData = transformAqlByStyle(kpiData?.aqlByStyle);
+  const topDefectsData = transformTopDefects(kpiData?.topDefects);
+  const auditedPiecesSeries = transformAuditedPieces(kpiData?.auditedPieces);
+  const rejectedEvolutionSeries = transformRejectedEvolution(kpiData?.rejectedEvolution);
+  const acReRateByLineData = transformAcReRateByLine(kpiData?.acReRateByLine);
+  const perfByCustomerData = transformPerformanceByCustomer(kpiData?.performanceByCustomer);
+  const perfByLineData = transformPerformanceByLine(kpiData?.performanceByLine);
+  const secondsReworkSeries = transformSecondsRework(kpiData?.secondsRework);
+  const fabricDefectsData = transformFabricDefects(kpiData?.fabricDefects);
+  const containersByStateData = transformContainersByState(kpiData?.containersByState);
+  const defectsByStyleTypeData = transformDefectsByStyleType(kpiData?.defectsByStyleType);
+
+  const isNullOrError = (data) => data === null || (data && data.error);
+
+  const nullMessage = "No disponible en modo rápido";
+
+  return (
+    <div className="dashboard-view">
+      <div className="dashboard-header">
+        <h1 className="dashboard-title">Dashboard de KPIs</h1>
+        <button className="refresh-btn" onClick={handleRefresh} disabled={loading}>
+          {loading ? 'Cargando...' : 'Actualizar'}
+        </button>
+      </div>
+
+      {isLiveMode && (
+        <FilterBar
+          filters={filters}
+          onFilterChange={handleFilterChange}
+          onApply={handleApply}
+          onReset={handleReset}
+        />
+      )}
+
+      <div className="dashboard-grid">
+        {/* Row 1: Defect Rate, Pass/Reject, AQL Weekly */}
+        <KpiCard title="Tasa de Defectos" loading={loading} error={error}>
+          <KpiNumberCard
+            title="Defect Rate"
+            value={defectRate !== null && !isNullOrError(defectRate) ? defectRate : null}
+            unit="%"
+            label="defectos / muestra × 100"
+          />
+        </KpiCard>
+
+        <KpiCard title="Distribución Pass / Reject" loading={loading} error={error}>
+          {isNullOrError(passRejectData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <DonutChartKpi data={passRejectData} />
+          )}
+        </KpiCard>
+
+        <KpiCard title="AQL Semanal" loading={loading} error={error}>
+          {isNullOrError(aqlWeeklySeries) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <LineChartKpi series={aqlWeeklySeries} />
+          )}
+        </KpiCard>
+
+        {/* Row 2: AQL by Style, Top Defects */}
+        <KpiCard title="AQL por Estilo" loading={loading} error={error}>
+          {isNullOrError(aqlByStyleData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={aqlByStyleData} horizontal color="#3b82f6" />
+          )}
+        </KpiCard>
+
+        <KpiCard title="Top Defectos" loading={loading} error={error}>
+          {isNullOrError(topDefectsData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={topDefectsData} horizontal color="#ef4444" />
+          )}
+        </KpiCard>
+
+        {/* Row 3: Audited Pieces, Rejected Evolution */}
+        <KpiCard title="Piezas Auditadas" loading={loading} error={error}>
+          {isNullOrError(auditedPiecesSeries) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <LineChartKpi series={auditedPiecesSeries} />
+          )}
+        </KpiCard>
+
+        <KpiCard title="Evolución Rechazadas" loading={loading} error={error}>
+          {isNullOrError(rejectedEvolutionSeries) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <LineChartKpi series={rejectedEvolutionSeries} />
+          )}
+        </KpiCard>
+
+        {/* Row 4: Ac/Re Rate by Line, Perf by Customer */}
+        <KpiCard title="Tasa Aceptación/Rechazo por Línea" loading={loading} error={error}>
+          {isNullOrError(acReRateByLineData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={acReRateByLineData} color="#10b981" />
+          )}
+        </KpiCard>
+
+        <KpiCard title="Performance por Cliente" loading={loading} error={error}>
+          {isNullOrError(perfByCustomerData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={perfByCustomerData} color="#8b5cf6" />
+          )}
+        </KpiCard>
+
+        {/* Row 5: Perf by Line, Seconds Rework */}
+        <KpiCard title="Performance por Línea" loading={loading} error={error}>
+          {isNullOrError(perfByLineData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={perfByLineData} horizontal color="#f59e0b" />
+          )}
+        </KpiCard>
+
+        <KpiCard title="Tiempo de Rework (segundos)" loading={loading} error={error}>
+          {isNullOrError(secondsReworkSeries) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <LineChartKpi series={secondsReworkSeries} />
+          )}
+        </KpiCard>
+
+        {/* Row 6: Fabric Defects, Containers by State */}
+        <KpiCard title="Defectos de Tela" loading={loading} error={error}>
+          {isNullOrError(fabricDefectsData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <BarChartKpi data={fabricDefectsData} color="#ec4899" />
+          )}
+        </KpiCard>
+
+        <KpiCard title="Contenedores por Estado" loading={loading} error={error}>
+          {isNullOrError(containersByStateData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <DonutChartKpi data={containersByStateData} />
+          )}
+        </KpiCard>
+
+        {/* Row 7: Defects by Style × Type (full width) */}
+        <KpiCard title="Defectos por Estilo × Tipo" loading={loading} error={error} className="full-width">
+          {isNullOrError(defectsByStyleTypeData) ? (
+            <div className="null-message">{nullMessage}</div>
+          ) : (
+            <HeatmapKpi data={defectsByStyleTypeData} />
+          )}
+        </KpiCard>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ✅ API client for 14 KPI endpoints (`api/kpi.js`)
- ✅ Pure calculation functions for Excel volatile mode (`utils/kpiCalculations.js`)
- ✅ 6 chart components (Bar, Line, Donut, Heatmap, KpiNumberCard, KpiCard wrapper)
- ✅ FilterBar with 7 global filters
- ✅ DashboardView with live (API) and volatile (Excel) modes
- ✅ Integration: App.jsx routing, Sidebar item, ExcelUploader "Ver Dashboard" button
- ✅ 36 tests passing (26 calculations + 5 KpiCard + 5 FilterBar)

### Components

| Component | Description |
|-----------|-------------|
| `BarChartKpi` | Horizontal/vertical bar charts |
| `LineChartKpi` | Multi-series line charts |
| `DonutChartKpi` | Donut/pie charts |
| `HeatmapKpi` | HTML table with color scale |
| `KpiNumberCard` | Large number display card |
| `KpiCard` | Generic wrapper (loading/error/empty) |
| `FilterBar` | 7 global filters with apply/reset |

### Dashboard Modes
- **Live**: Fetches from `/api/kpis/` endpoints with filters
- **Volatile**: Calculates KPIs in-memory from Excel preview data (no DB write)

### Commits
- `240afa6` — feat(kpi): add API client for 14 dashboard endpoints
- `1ff5614` — feat(kpi): add pure calculation functions for volatile Excel dashboard mode
- `b675af4` — feat(kpi): add chart components (bar, line, donut, heatmap, card, filter)
- `41e8988` — feat(kpi): add DashboardView with live and volatile modes
- `4550d7c` — feat(kpi): integrate dashboard with app, sidebar, and Excel uploader

### Test Results
```
KPI Tests: 36/36 passing
- kpiCalculations.test.js: 26 tests
- KpiCard.test.jsx: 5 tests
- FilterBar.test.jsx: 5 tests
```