### PR TITLE
fix(container): persist import dates for filters and preview

### DIFF
--- a/backend/excel_importer/date_utils.py
+++ b/backend/excel_importer/date_utils.py
@@ -124,3 +124,15 @@ def _parse_excel_serial(serial):
         return result_date.strftime("%Y-%m-%d")
     except (ValueError, OverflowError, TypeError):
         return None
+
+
+def normalize_container_date(value):
+    """Return a Python date for Container.date or None when unparseable."""
+    normalized = parse_date(value)
+    if not normalized:
+        return None
+
+    try:
+        return datetime.date.fromisoformat(normalized)
+    except (TypeError, ValueError):
+        return None

--- a/backend/excel_importer/date_utils.py
+++ b/backend/excel_importer/date_utils.py
@@ -7,6 +7,7 @@ for comparison during Time-Window Sync.
 """
 
 import datetime
+import numbers
 import re
 
 import pandas as pd
@@ -47,7 +48,7 @@ def parse_date(value):
         return value.strftime("%Y-%m-%d")
 
     # Handle numeric values (Excel serial dates)
-    if isinstance(value, (int, float)):
+    if isinstance(value, numbers.Real) and not isinstance(value, bool):
         return _parse_excel_serial(value)
 
     # Handle strings
@@ -91,7 +92,7 @@ def _parse_date_string(value):
     ]
 
     for pattern in month_name_patterns:
-        match = re.match(pattern, value)
+        match = re.fullmatch(pattern, value)
         if match:
             groups = match.groups()
             try:
@@ -115,12 +116,22 @@ def _parse_excel_serial(serial):
     """
     Convert an Excel serial date number to 'YYYY-MM-DD' string.
 
-    Excel uses a serial number system where day 1 is December 30, 1899.
+    Excel uses a serial number system where day 1 maps to 1900-01-01,
+    with a historical leap-year bug at serial 60 (1900-02-29, non-existent).
+    We collapse serial 60 to 1900-02-28 so Python date conversion stays valid.
     """
     try:
-        # Excel epoch is 1899-12-30
-        epoch = datetime.date(1899, 12, 30)
-        result_date = epoch + datetime.timedelta(days=int(serial))
+        serial_int = int(serial)
+
+        if serial_int <= 0:
+            return None
+
+        # Serial 60 represents Excel's fake 1900-02-29; collapse to 1900-02-28.
+        if serial_int >= 60:
+            serial_int -= 1
+
+        epoch = datetime.date(1899, 12, 31)
+        result_date = epoch + datetime.timedelta(days=serial_int)
         return result_date.strftime("%Y-%m-%d")
     except (ValueError, OverflowError, TypeError):
         return None

--- a/backend/excel_importer/handler_service.py
+++ b/backend/excel_importer/handler_service.py
@@ -10,7 +10,7 @@ from quality_data.models import (
     SecondsA4,
     SecondsGeneral,
 )
-from excel_importer.date_utils import parse_date
+from excel_importer.date_utils import normalize_container_date, parse_date
 
 
 def _normalize_defects_fields(defeacts_fields):
@@ -267,10 +267,25 @@ def bulk_insert_container(df, numeric_columns, not_numeric_columns, defeacts_fie
         return
 
     container_instances = []
+    container_numbers = df['container_number'].dropna().unique().tolist()
+    container_numbers = [int(num) for num in container_numbers if pd.notna(num)]
+    existing_dates = {
+        c.container_number: c.date
+        for c in Container.objects.filter(container_number__in=container_numbers)
+    }
 
     for _, row in df.iterrows():
         production_data = {field: row.get(field, 0) for field in numeric_columns}
         production_data.update({field: row.get(field, "UNKNOWN") for field in not_numeric_columns})
+        container_number = row.get('container_number')
+        if pd.notna(container_number):
+            container_number = int(container_number)
+            production_data['container_number'] = container_number
+
+        production_data['date'] = _resolve_container_date(
+            row.get('date'),
+            existing_dates.get(container_number),
+        )
         production_data = _truncate_charfields(Container, production_data)
 
         container_instances.append(Container(**production_data))
@@ -284,14 +299,12 @@ def bulk_insert_container(df, numeric_columns, not_numeric_columns, defeacts_fie
         unique_fields=['container_number'],
         update_fields=['customer', 'transfer_of_container', 'total_palette', 
                        'total_palette_pass', 'total_palette_rejected', 
-                       'percentage_pass', 'percentage_reject']
+                       'percentage_pass', 'percentage_reject', 'date']
     )
 
     # Build a deterministic mapping from container_number to Container instance
     # by re-querying the database. This ensures we get the actual persisted
     # container (either newly created or existing) for correct defect linking.
-    container_numbers = df['container_number'].dropna().unique().tolist()
-    container_numbers = [int(num) for num in container_numbers if pd.notna(num)]
     containers_by_number = {
         c.container_number: c 
         for c in Container.objects.filter(container_number__in=container_numbers)
@@ -332,3 +345,11 @@ def bulk_insert_container(df, numeric_columns, not_numeric_columns, defeacts_fie
             batch_size=2000,
             ignore_conflicts=True  # Skip duplicate (container, defect_type) pairs
         )
+
+
+def _resolve_container_date(raw_date, existing_date):
+    """Preserve existing non-null date when import date is empty/invalid."""
+    normalized = normalize_container_date(raw_date)
+    if normalized is not None:
+        return normalized
+    return existing_date

--- a/backend/excel_importer/sheet_configs.py
+++ b/backend/excel_importer/sheet_configs.py
@@ -243,6 +243,7 @@ SECONDS_GENERAL_NOT_NUMERIC_COLUMNS = [
 
 
 CONTAINER_REMAP = {
+    'Date': 'date',
     '# Container': 'container_number',
     'Customer': 'customer',
     '# Transfert of Container': 'transfer_of_container',
@@ -274,7 +275,7 @@ CONTAINER_NUMERIC_COLUMNS = [
 ]
 
 CONTAINER_NOT_NUMERIC_COLUMNS = [
-    'customer'
+    'customer', 'date'
 ]
 
 CONTAINER_AMOUNT_DEFEACTS_FIELDS = [

--- a/backend/excel_importer/sync_service.py
+++ b/backend/excel_importer/sync_service.py
@@ -17,7 +17,7 @@ from quality_data.models import (
     Color,
     ExcelSyncSession,
 )
-from excel_importer.date_utils import parse_date
+from excel_importer.date_utils import normalize_container_date, parse_date
 
 
 # ─────────────────────────────────────────────────────────
@@ -423,7 +423,9 @@ def create_session_from_dataframes(dataframes):
     session.qc_fa_customer_data = dataframes.get("qc_fa_customer", [])
     session.seconds_a4_data = dataframes.get("seconds_a4", [])
     session.seconds_general_data = dataframes.get("seconds_general", [])
-    session.container_data = dataframes.get("container", [])
+    raw_container_rows = dataframes.get("container", [])
+    container_rows, container_warnings = _normalize_container_rows(raw_container_rows)
+    session.container_data = container_rows
 
     # Compute previews
     session.qc_fa_plant_preview = compute_preview_timewindow(
@@ -464,6 +466,7 @@ def create_session_from_dataframes(dataframes):
                           "seconds_general_preview"]:
         preview = getattr(session, preview_field)
         all_warnings.extend(preview.get("warnings", []))
+    all_warnings.extend(container_warnings)
     session.warnings = all_warnings
 
     session.save()
@@ -574,6 +577,9 @@ def _build_instance(model_class, row, numeric_columns, not_numeric_columns,
         color_obj, _ = Color.objects.get_or_create(name=color_name, defaults={"is_active": True})
         data["color"] = color_obj
 
+    if model_class == Container:
+        data["date"] = normalize_container_date(row.get("date"))
+
     return model_class(**data)
 
 
@@ -586,6 +592,8 @@ def _update_instance(instance, row, numeric_columns, not_numeric_columns):
             setattr(instance, field, row[field])
     for field in (not_numeric_columns or []):
         if field in row and field not in fk_fields:
+            if isinstance(instance, Container) and field == "date":
+                continue
             setattr(instance, field, row[field])
 
     # Handle FK fields
@@ -593,6 +601,11 @@ def _update_instance(instance, row, numeric_columns, not_numeric_columns):
         color_name = str(row.get("color", "unknown")).strip().lower().replace(" ", "_")
         color_obj, _ = Color.objects.get_or_create(name=color_name, defaults={"is_active": True})
         instance.color = color_obj
+
+    if isinstance(instance, Container) and "date" in row:
+        normalized = normalize_container_date(row.get("date"))
+        if normalized is not None:
+            instance.date = normalized
 
 
 def _model_to_dict(obj):
@@ -736,3 +749,29 @@ def _get_not_numeric_columns_for_model(model_class):
     elif model_class == Container:
         return CONTAINER_NOT_NUMERIC_COLUMNS
     return []
+
+
+def _normalize_container_rows(rows):
+    """Normalize container date values and emit warnings for invalid input."""
+    normalized_rows = []
+    warnings = []
+
+    for row in rows:
+        normalized_row = dict(row)
+        raw_date = normalized_row.get("date")
+        normalized_date = normalize_container_date(raw_date)
+
+        if normalized_date is not None:
+            normalized_row["date"] = normalized_date.isoformat()
+        else:
+            normalized_row["date"] = None
+            raw_text = str(raw_date).strip() if raw_date is not None else ""
+            if raw_text:
+                container_number = normalized_row.get("container_number", "unknown")
+                warnings.append(
+                    f"Container {container_number}: invalid date '{raw_text}' stored as NULL."
+                )
+
+        normalized_rows.append(normalized_row)
+
+    return normalized_rows, warnings

--- a/backend/excel_importer/tests/test_date_utils.py
+++ b/backend/excel_importer/tests/test_date_utils.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
-from excel_importer.date_utils import parse_date
+import datetime
+
+from excel_importer.date_utils import parse_date, normalize_container_date
 
 
 class ParseDateTest(TestCase):
@@ -80,3 +82,13 @@ class ParseDateTest(TestCase):
         """Given 'January 15, 2025', returns normalized '2025-01-15'."""
         result = parse_date("January 15, 2025")
         self.assertEqual(result, "2025-01-15")
+
+
+class NormalizeContainerDateTest(TestCase):
+    def test_returns_python_date_for_valid_input(self):
+        result = normalize_container_date("2025-03-12")
+        self.assertEqual(result, datetime.date(2025, 3, 12))
+
+    def test_returns_none_for_invalid_or_empty_input(self):
+        self.assertIsNone(normalize_container_date("UNKNOWN"))
+        self.assertIsNone(normalize_container_date(""))

--- a/backend/excel_importer/tests/test_date_utils.py
+++ b/backend/excel_importer/tests/test_date_utils.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 import datetime
+import numpy as np
+import pandas as pd
 
 from excel_importer.date_utils import parse_date, normalize_container_date
 
@@ -62,14 +64,12 @@ class ParseDateTest(TestCase):
 
     def test_parse_pandas_timestamp(self):
         """Given a pandas Timestamp, returns normalized string."""
-        import pandas as pd
         ts = pd.Timestamp("2025-06-20")
         result = parse_date(ts)
         self.assertEqual(result, "2025-06-20")
 
     def test_parse_pandas_nat(self):
         """Given a pandas NaT (empty date cell), returns None instead of crashing."""
-        import pandas as pd
         result = parse_date(pd.NaT)
         self.assertIsNone(result)
 
@@ -83,6 +83,10 @@ class ParseDateTest(TestCase):
         result = parse_date("January 15, 2025")
         self.assertEqual(result, "2025-01-15")
 
+    def test_parse_month_name_with_trailing_text_returns_none(self):
+        self.assertIsNone(parse_date("January 15, 2025 trailing"))
+        self.assertIsNone(parse_date("15 January 2025 trailing"))
+
 
 class NormalizeContainerDateTest(TestCase):
     def test_returns_python_date_for_valid_input(self):
@@ -92,3 +96,43 @@ class NormalizeContainerDateTest(TestCase):
     def test_returns_none_for_invalid_or_empty_input(self):
         self.assertIsNone(normalize_container_date("UNKNOWN"))
         self.assertIsNone(normalize_container_date(""))
+
+    def test_returns_python_date_for_excel_serial_float(self):
+        result = normalize_container_date(45672.9)
+        self.assertIsInstance(result, datetime.date)
+
+
+class ParseDateAdditionalCoverageTest(TestCase):
+    def test_parse_date_object(self):
+        result = parse_date(datetime.date(2025, 4, 7))
+        self.assertEqual(result, "2025-04-07")
+
+    def test_parse_invalid_types_and_placeholders(self):
+        self.assertIsNone(parse_date(object()))
+        self.assertIsNone(parse_date("N/A"))
+        self.assertIsNone(parse_date("NONE"))
+        self.assertIsNone(parse_date("NULL"))
+
+    def test_parse_month_name_with_day_first_and_abbrev(self):
+        self.assertEqual(parse_date("15 January 2025"), "2025-01-15")
+        self.assertEqual(parse_date("Jan 15 2025"), "2025-01-15")
+
+    def test_parse_excel_serial_invalid_number_returns_none(self):
+        self.assertIsNone(parse_date(float("inf")))
+
+    def test_parse_excel_serial_exact_early_values(self):
+        self.assertEqual(parse_date(1), "1900-01-01")
+        self.assertEqual(parse_date(59), "1900-02-28")
+        self.assertEqual(parse_date(60), "1900-02-28")
+        self.assertEqual(parse_date(61), "1900-03-01")
+
+    def test_parse_excel_serial_zero_and_negative_values(self):
+        self.assertIsNone(parse_date(0))
+        self.assertIsNone(parse_date(-1))
+
+    def test_parse_excel_serial_numpy_integer_scalar(self):
+        self.assertEqual(parse_date(np.int64(45672)), "2025-01-15")
+
+    def test_parse_excel_serial_pandas_integer_scalar(self):
+        serial = pd.array([45672], dtype="Int64")[0]
+        self.assertEqual(parse_date(serial), "2025-01-15")

--- a/backend/excel_importer/tests/test_handler_service.py
+++ b/backend/excel_importer/tests/test_handler_service.py
@@ -15,7 +15,10 @@ from quality_data.models import (
 )
 from excel_importer.handler_service import (
     _bulk_insert_defects_only,
+    bulk_insert,
     bulk_insert_container,
+    bulk_insert_seconds_a4,
+    bulk_insert_seconds_general,
     load_and_clean,
     load_pivot_range,
     _normalize_defects_fields,
@@ -194,6 +197,89 @@ class BulkInsertDefectsOnlyTest(TestCase):
         # Should not raise - missing parents are skipped
         _bulk_insert_defects_only(df, ["sew_def"], "QFA")
 
+        self.assertEqual(InspectionDefect.objects.count(), 0)
+
+    def test_missing_color_skips_row_without_crashing(self):
+        quality = QualityQcFa.objects.create(
+            table_type="QFA",
+            date_1="2025-01-15",
+            week=3,
+            customer="A4",
+            team=1,
+            coord="JAVIER",
+            po=195221,
+            style="N3165",
+            batch=1,
+            color=self.color,
+            qty=100,
+            seconds=50,
+            accepted=40,
+            rejected=10,
+            sample=5,
+            defects_total=0,
+            aql=2.5,
+            pass_or_fail="Pass",
+        )
+        self.assertIsNotNone(quality)
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "date_1": "2025-01-15",
+                "po": 195221,
+                "style": "N3165",
+                "team": 1,
+                "color": "missing-color",
+                "sew_def": 5,
+            }
+        ])
+
+        _bulk_insert_defects_only(df, ["sew_def"], "QFA")
+        self.assertEqual(InspectionDefect.objects.count(), 0)
+
+    def test_missing_style_or_date_skips_row(self):
+        QualityQcFa.objects.create(
+            table_type="QFA",
+            date_1="2025-01-15",
+            week=3,
+            customer="A4",
+            team=1,
+            coord="JAVIER",
+            po=195221,
+            style="N3165",
+            batch=1,
+            color=self.color,
+            qty=100,
+            seconds=50,
+            accepted=40,
+            rejected=10,
+            sample=5,
+            defects_total=0,
+            aql=2.5,
+            pass_or_fail="Pass",
+        )
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "date_1": "",
+                "po": 195221,
+                "style": "N3165",
+                "team": 1,
+                "color": "red",
+                "sew_def": 5,
+            },
+            {
+                "date_1": "2025-01-15",
+                "po": 195221,
+                "style": "",
+                "team": 1,
+                "color": "red",
+                "sew_def": 5,
+            },
+        ])
+
+        _bulk_insert_defects_only(df, ["sew_def"], "QFA")
         self.assertEqual(InspectionDefect.objects.count(), 0)
 
 
@@ -571,6 +657,239 @@ class BulkInsertContainerTest(TestCase):
 
         container = Container.objects.get(container_number=2002)
         self.assertEqual(container.date, datetime.date(2025, 3, 1))
+
+    def test_reimport_with_invalid_date_preserves_existing_non_null_date(self):
+        Container.objects.create(
+            container_number=2003,
+            customer="CUST_KEEP_INVALID",
+            transfer_of_container=1,
+            total_palette=10,
+            total_palette_pass=9,
+            total_palette_rejected=1,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+            date=datetime.date(2025, 4, 2),
+        )
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "container_number": 2003,
+                "customer": "CUST_KEEP_INVALID",
+                "transfer_of_container": 2,
+                "total_palette": 11,
+                "total_palette_pass": 10,
+                "total_palette_rejected": 1,
+                "percentage_pass": 91.0,
+                "percentage_reject": 9.0,
+                "date": "NOT_A_DATE",
+                "cont_sew_def": 0,
+            }
+        ])
+
+        bulk_insert_container(
+            df,
+            ["transfer_of_container", "total_palette", "total_palette_pass", "total_palette_rejected", "percentage_pass", "percentage_reject"],
+            ["customer", "container_number", "date"],
+            ["cont_sew_def"],
+        )
+
+        container = Container.objects.get(container_number=2003)
+        self.assertEqual(container.date, datetime.date(2025, 4, 2))
+
+
+class BulkInsertCoverageTest(TestCase):
+    def setUp(self):
+        self.color = Color.objects.create(name="teal", is_active=True)
+        self.defect_type = DefectType.objects.create(name="sew_def")
+
+    def test_bulk_insert_returns_when_dataframe_is_empty(self):
+        import pandas as pd
+        df = pd.DataFrame([])
+
+        bulk_insert(
+            df,
+            numeric_columns=["qty", "seconds"],
+            not_numeric_columns=["customer", "style", "date_1", "table_type", "coord", "pass_or_fail"],
+            defeacts_fields=["sew_def"],
+            table_type="QFA",
+        )
+
+        self.assertEqual(QualityQcFa.objects.count(), 0)
+
+    def test_bulk_insert_creates_quality_and_defects(self):
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "date_1": "2025-01-15",
+                "week": 3,
+                "customer": "A4",
+                "team": 1,
+                "coord": "JAVIER",
+                "po": 195221,
+                "style": "N3165",
+                "batch": 1,
+                "color": "teal",
+                "qty": 100,
+                "seconds": 50,
+                "accepted": 40,
+                "rejected": 10,
+                "sample": 5,
+                "defects_total": 5,
+                "aql": 2.5,
+                "pass_or_fail": "PASS",
+                "sew_def": 3,
+            }
+        ])
+
+        bulk_insert(
+            df,
+            numeric_columns=["week", "team", "po", "batch", "qty", "seconds", "accepted", "rejected", "sample", "defects_total", "aql"],
+            not_numeric_columns=["date_1", "customer", "coord", "style", "pass_or_fail"],
+            defeacts_fields=["sew_def"],
+            table_type="QFA",
+        )
+
+        self.assertEqual(QualityQcFa.objects.count(), 1)
+        created = QualityQcFa.objects.first()
+        self.assertEqual(created.table_type, "QFA")
+        self.assertEqual(created.color.name, "teal")
+        self.assertEqual(InspectionDefect.objects.count(), 1)
+        self.assertEqual(InspectionDefect.objects.first().amount, 3)
+
+    def test_bulk_insert_defects_only_uses_existing_parents(self):
+        quality = QualityQcFa.objects.create(
+            table_type="QFA",
+            date_1="2025-02-01",
+            week=1,
+            customer="A4",
+            team=1,
+            coord="TEST",
+            po=123,
+            style="STYLE",
+            batch=1,
+            color=self.color,
+            qty=10,
+            seconds=2,
+            accepted=8,
+            rejected=2,
+            sample=2,
+            defects_total=0,
+            aql=1.0,
+            pass_or_fail="PASS",
+        )
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "date_1": "2025-02-01",
+                "po": 123,
+                "style": "STYLE",
+                "team": 1,
+                "color": "teal",
+                "sew_def": 4,
+            }
+        ])
+
+        bulk_insert(
+            df,
+            numeric_columns=[],
+            not_numeric_columns=[],
+            defeacts_fields=["sew_def"],
+            table_type="QFA",
+            defects_only=True,
+        )
+
+        defect = InspectionDefect.objects.get()
+        self.assertEqual(defect.inspection, quality)
+        self.assertEqual(defect.amount, 4)
+
+
+class BulkInsertSecondsCoverageTest(TestCase):
+    def setUp(self):
+        self.color = Color.objects.create(name="orange", is_active=True)
+
+    def test_bulk_insert_seconds_a4_noop_with_empty_dataframe(self):
+        import pandas as pd
+        from quality_data.models import SecondsA4
+
+        bulk_insert_seconds_a4(pd.DataFrame([]), ["year"], ["date"])
+        self.assertEqual(SecondsA4.objects.count(), 0)
+
+    def test_bulk_insert_seconds_general_noop_with_empty_dataframe(self):
+        import pandas as pd
+        from quality_data.models import SecondsGeneral
+
+        bulk_insert_seconds_general(pd.DataFrame([]), ["week"], ["date"])
+        self.assertEqual(SecondsGeneral.objects.count(), 0)
+
+    def test_bulk_insert_seconds_a4_creates_records(self):
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "year": 2025,
+                "week": 10,
+                "date": "2025-03-01",
+                "cut_num": 10,
+                "style": "STYLE-A",
+                "cut_qty": 200,
+                "color": "orange",
+                "first_quality_qty_sewing": 150,
+                "sample": 10,
+                "pass_field": 140,
+                "fail_field": 10,
+                "sew_def": 4,
+                "fab_def": 6,
+                "accepted": 180,
+                "rejected": 20,
+                "total_of_2ds": 5,
+                "percentage_of_2ds": 2.5,
+                "line": "L1",
+                "seconds_by_sew": 3,
+                "seconds_by_fab": 2,
+                "seconds_sew_a4": 1,
+                "seconds_fab_a4": 1,
+            }
+        ])
+
+        bulk_insert_seconds_a4(
+            df,
+            [
+                "year", "week", "cut_num", "cut_qty", "first_quality_qty_sewing", "sample", "pass_field", "fail_field",
+                "sew_def", "fab_def", "accepted", "rejected", "total_of_2ds", "percentage_of_2ds",
+                "seconds_by_sew", "seconds_by_fab", "seconds_sew_a4", "seconds_fab_a4",
+            ],
+            ["date", "style", "line", "color"],
+        )
+
+        from quality_data.models import SecondsA4
+        self.assertEqual(SecondsA4.objects.count(), 1)
+        self.assertEqual(SecondsA4.objects.first().style, "STYLE-A")
+
+    def test_bulk_insert_seconds_general_creates_records(self):
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "date": "2025-03-01",
+                "week": 10,
+                "corrido_2": 5,
+                "barre": 3,
+                "otros_3": 2,
+                "degradacion": 1,
+                "bordados": 0,
+                "total_de_tela": 11,
+            }
+        ])
+
+        bulk_insert_seconds_general(
+            df,
+            ["week", "corrido_2", "barre", "otros_3", "degradacion", "bordados", "total_de_tela"],
+            ["date"],
+        )
+
+        from quality_data.models import SecondsGeneral
+        self.assertEqual(SecondsGeneral.objects.count(), 1)
+        self.assertEqual(SecondsGeneral.objects.first().total_de_tela, 11)
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/excel_importer/tests/test_handler_service.py
+++ b/backend/excel_importer/tests/test_handler_service.py
@@ -2,6 +2,7 @@
 Tests for handler_service bulk insert functions, specifically the defects-only path.
 """
 import io
+import datetime
 from django.test import TestCase
 from quality_data.models import (
     Color,
@@ -20,6 +21,7 @@ from excel_importer.handler_service import (
     _normalize_defects_fields,
     _truncate_charfields,
 )
+from excel_importer.sheet_configs import CONTAINER_REMAP, CONTAINER_NOT_NUMERIC_COLUMNS
 from quality_data.models import QualityQcFa as QfaModel
 
 
@@ -492,6 +494,84 @@ class BulkInsertContainerTest(TestCase):
         self.assertEqual(defect.container, existing_container)
         self.assertEqual(defect.amount, 10)
 
+    def test_reimport_updates_container_date_when_valid_date_is_present(self):
+        Container.objects.create(
+            container_number=2001,
+            customer="CUST_DATE",
+            transfer_of_container=1,
+            total_palette=10,
+            total_palette_pass=9,
+            total_palette_rejected=1,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+            date=datetime.date(2025, 1, 10),
+        )
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "container_number": 2001,
+                "customer": "CUST_DATE",
+                "transfer_of_container": 1,
+                "total_palette": 10,
+                "total_palette_pass": 9,
+                "total_palette_rejected": 1,
+                "percentage_pass": 90.0,
+                "percentage_reject": 10.0,
+                "date": "2025-02-15",
+                "cont_sew_def": 0,
+            }
+        ])
+
+        bulk_insert_container(
+            df,
+            ["transfer_of_container", "total_palette", "total_palette_pass", "total_palette_rejected", "percentage_pass", "percentage_reject"],
+            ["customer", "container_number", "date"],
+            ["cont_sew_def"],
+        )
+
+        container = Container.objects.get(container_number=2001)
+        self.assertEqual(container.date, datetime.date(2025, 2, 15))
+
+    def test_reimport_with_empty_date_preserves_existing_non_null_date(self):
+        Container.objects.create(
+            container_number=2002,
+            customer="CUST_KEEP_DATE",
+            transfer_of_container=1,
+            total_palette=10,
+            total_palette_pass=9,
+            total_palette_rejected=1,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+            date=datetime.date(2025, 3, 1),
+        )
+
+        import pandas as pd
+        df = pd.DataFrame([
+            {
+                "container_number": 2002,
+                "customer": "CUST_KEEP_DATE",
+                "transfer_of_container": 2,
+                "total_palette": 11,
+                "total_palette_pass": 10,
+                "total_palette_rejected": 1,
+                "percentage_pass": 91.0,
+                "percentage_reject": 9.0,
+                "date": "",
+                "cont_sew_def": 0,
+            }
+        ])
+
+        bulk_insert_container(
+            df,
+            ["transfer_of_container", "total_palette", "total_palette_pass", "total_palette_rejected", "percentage_pass", "percentage_reject"],
+            ["customer", "container_number", "date"],
+            ["cont_sew_def"],
+        )
+
+        container = Container.objects.get(container_number=2002)
+        self.assertEqual(container.date, datetime.date(2025, 3, 1))
+
 
 # ─────────────────────────────────────────────────────────
 # Phase 1: load_and_clean Edge Case Tests
@@ -609,6 +689,10 @@ class LoadAndCleanEdgeCasesTest(TestCase):
                 0,
                 5,
             )
+
+    def test_container_sheet_config_maps_date_column(self):
+        self.assertEqual(CONTAINER_REMAP.get("Date"), "date")
+        self.assertIn("date", CONTAINER_NOT_NUMERIC_COLUMNS)
 
 
 class LoadPivotRangeIOTest(TestCase):

--- a/backend/excel_importer/tests/test_sync_service.py
+++ b/backend/excel_importer/tests/test_sync_service.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+import datetime
 from quality_data.models import (
     QualityQcFa,
     SecondsA4,
@@ -291,6 +292,96 @@ class ApplyUpsertTest(TestCase):
         self.assertEqual(obj.total_palette, 22)
         self.assertEqual(obj.transfer_of_container, 11)
 
+    def test_container_upsert_preserves_existing_date_when_reimport_date_empty(self):
+        Container.objects.create(
+            container_number=15,
+            customer="A4",
+            transfer_of_container=10,
+            total_palette=20,
+            total_palette_pass=18,
+            total_palette_rejected=2,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+            date=datetime.date(2025, 1, 20),
+        )
+
+        excel_rows = [
+            {
+                "container_number": 15,
+                "customer": "A4",
+                "transfer_of_container": 11,
+                "total_palette": 21,
+                "total_palette_pass": 19,
+                "total_palette_rejected": 2,
+                "percentage_pass": 90.4,
+                "percentage_reject": 9.6,
+                "date": "",
+            }
+        ]
+
+        apply_upsert(
+            excel_rows,
+            Container,
+            build_container_key,
+            not_numeric_columns=["customer", "container_number", "date"],
+            numeric_columns=[
+                "transfer_of_container",
+                "total_palette",
+                "total_palette_pass",
+                "total_palette_rejected",
+                "percentage_pass",
+                "percentage_reject",
+            ],
+        )
+
+        obj = Container.objects.get(container_number=15)
+        self.assertEqual(obj.date, datetime.date(2025, 1, 20))
+
+    def test_container_upsert_updates_date_when_reimport_has_valid_date(self):
+        Container.objects.create(
+            container_number=16,
+            customer="A4",
+            transfer_of_container=10,
+            total_palette=20,
+            total_palette_pass=18,
+            total_palette_rejected=2,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+            date=datetime.date(2025, 1, 20),
+        )
+
+        excel_rows = [
+            {
+                "container_number": 16,
+                "customer": "A4",
+                "transfer_of_container": 11,
+                "total_palette": 21,
+                "total_palette_pass": 19,
+                "total_palette_rejected": 2,
+                "percentage_pass": 90.4,
+                "percentage_reject": 9.6,
+                "date": "2025-02-22",
+            }
+        ]
+
+        apply_upsert(
+            excel_rows,
+            Container,
+            build_container_key,
+            not_numeric_columns=["customer", "container_number", "date"],
+            numeric_columns=[
+                "transfer_of_container",
+                "total_palette",
+                "total_palette_pass",
+                "total_palette_rejected",
+                "percentage_pass",
+                "percentage_reject",
+            ],
+        )
+
+        obj = Container.objects.get(container_number=16)
+        self.assertEqual(obj.date, datetime.date(2025, 2, 22))
+
 
 class ApplyTimeWindowTest(TestCase):
     """Tests for apply_timewindow."""
@@ -408,3 +499,20 @@ class SessionManagementTest(TestCase):
         apply_session(session)
         session.refresh_from_db()
         self.assertEqual(session.status, "confirmed")
+
+    def test_create_session_container_preview_tracks_dates_and_invalid_warnings(self):
+        dataframes = {
+            "qc_fa_plant": [],
+            "seconds_a4": [],
+            "seconds_general": [],
+            "qc_fa_customer": [],
+            "container": [
+                {"container_number": 33, "date": "2025-02-01"},
+                {"container_number": 34, "date": "INVALID-DATE"},
+            ],
+        }
+
+        session = create_session_from_dataframes(dataframes)
+
+        self.assertEqual(session.container_preview["dates"], ["2025-02-01"])
+        self.assertTrue(any("container" in warning.lower() for warning in session.warnings))

--- a/backend/quality_data/migrations/0003_container_date.py
+++ b/backend/quality_data/migrations/0003_container_date.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("quality_data", "0002_add_kpi_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="container",
+            name="date",
+            field=models.DateField(blank=True, db_index=True, null=True),
+        ),
+    ]

--- a/backend/quality_data/models.py
+++ b/backend/quality_data/models.py
@@ -123,6 +123,7 @@ class ContainerDefectType(models.Model):
 
 class Container(models.Model):
     container_number = models.IntegerField(unique=True)
+    date = models.DateField(null=True, blank=True, db_index=True)
     customer = models.CharField(max_length=50, db_index=True)
     transfer_of_container = models.IntegerField(default=0)
     total_palette = models.IntegerField()

--- a/backend/quality_data/tests/test_excel_v2_views.py
+++ b/backend/quality_data/tests/test_excel_v2_views.py
@@ -12,6 +12,7 @@ from rest_framework import status
 from quality_data.models import (
     QualityQcFa,
     SecondsA4,
+    Container,
     Color,
     ExcelSyncSession,
 )
@@ -142,6 +143,28 @@ class ExcelConfirmViewTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+    def test_confirm_persists_container_date(self):
+        session = ExcelSyncSession.objects.create(
+            container_data=[{
+                "container_number": 500,
+                "customer": "TEST",
+                "transfer_of_container": 1,
+                "total_palette": 10,
+                "total_palette_pass": 9,
+                "total_palette_rejected": 1,
+                "percentage_pass": 90.0,
+                "percentage_reject": 10.0,
+                "date": "2025-04-10",
+            }],
+        )
+
+        url = reverse('quality_data:excel-confirm', kwargs={'session_id': session.pk})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        container = Container.objects.get(container_number=500)
+        self.assertEqual(str(container.date), "2025-04-10")
+
 
 class ExcelRejectViewTest(TestCase):
     """Tests for DELETE /excel/reject/<session_id>/"""
@@ -236,3 +259,24 @@ class FullWorkflowTest(TestCase):
         self.assertEqual(reject_response.status_code, status.HTTP_200_OK)
         session = ExcelSyncSession.objects.get(pk=session_id)
         self.assertEqual(session.status, 'rejected')
+
+    @patch('quality_data.views.load_and_clean')
+    def test_preview_returns_container_dates_and_invalid_date_warning(self, mock_load_and_clean):
+        mock_load_and_clean.side_effect = [
+            _make_mock_dataframe([]),
+            _make_mock_dataframe([]),
+            _make_mock_dataframe([]),
+            _make_mock_dataframe([]),
+            _make_mock_dataframe([
+                {"container_number": 777, "date": "2025-05-01"},
+                {"container_number": 778, "date": "BAD-DATE"},
+            ]),
+        ]
+
+        preview_url = reverse('quality_data:excel-preview', kwargs={'filename': 'test.xlsx'})
+        with open('/dev/null', 'rb') as f:
+            response = self.client.post(preview_url, {'file': f}, format='multipart')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["preview"]["container"]["dates"], ["2025-05-01"])
+        self.assertTrue(any("invalid date" in warning.lower() for warning in response.data["warnings"]))

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -752,6 +752,58 @@ class ContainersByStateTest(KpiTestMixin, TestCase):
         total = sum(item["value"] for item in response.data)
         self.assertEqual(total, Container.objects.count())
 
+    def test_from_date_to_date_filters_inclusive(self):
+        container_a = Container.objects.get(container_number=200)
+        container_b = Container.objects.get(container_number=201)
+        container_c = Container.objects.get(container_number=202)
+        container_a.date = "2025-01-10"
+        container_b.date = "2025-01-11"
+        container_c.date = "2025-01-12"
+        container_a.save()
+        container_b.save()
+        container_c.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?from_date=2025-01-10&to_date=2025-01-11")
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 2)
+
+    def test_date_filter_excludes_null_dates(self):
+        dated_container = Container.objects.get(container_number=200)
+        dated_container.date = "2025-01-10"
+        dated_container.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?from_date=2025-01-01&to_date=2025-01-31")
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 1)
+
+    def test_invalid_date_filters_return_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?from_date=10-01-2025&to_date=2025-01-31")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("from_date", response.data)
+
+    def test_invalid_to_date_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?from_date=2025-01-01&to_date=31-01-2025")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("to_date", response.data)
+
+    def test_no_date_filters_preserves_legacy_behavior(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 6)
+
 
 class DefectRateTest(KpiTestMixin, TestCase):
     """Tests for GET /quality/kpis/defect-rate/"""

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -782,6 +782,124 @@ class ContainersByStateTest(KpiTestMixin, TestCase):
         total = sum(item["value"] for item in response.data)
         self.assertEqual(total, 1)
 
+    def test_date_range_filters_inclusive(self):
+        container_a = Container.objects.get(container_number=200)
+        container_b = Container.objects.get(container_number=201)
+        container_c = Container.objects.get(container_number=202)
+        container_a.date = "2025-01-10"
+        container_b.date = "2025-01-11"
+        container_c.date = "2025-01-12"
+        container_a.save()
+        container_b.save()
+        container_c.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=2025-01-10,2025-01-11")
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 2)
+
+    def test_date_range_takes_precedence_over_from_to(self):
+        container_a = Container.objects.get(container_number=200)
+        container_b = Container.objects.get(container_number=201)
+        container_a.date = "2025-01-10"
+        container_b.date = "2025-01-12"
+        container_a.save()
+        container_b.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(
+            f"{url}?date_range=2025-01-10,2025-01-10&from_date=2025-01-01&to_date=2025-01-31"
+        )
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 1)
+
+    def test_blank_date_range_falls_back_to_from_to_filters(self):
+        container_a = Container.objects.get(container_number=200)
+        container_b = Container.objects.get(container_number=201)
+        container_c = Container.objects.get(container_number=202)
+        container_a.date = "2025-01-10"
+        container_b.date = "2025-01-11"
+        container_c.date = "2025-01-12"
+        container_a.save()
+        container_b.save()
+        container_c.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(
+            f"{url}?date_range=&from_date=2025-01-10&to_date=2025-01-11"
+        )
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 2)
+
+    def test_blank_date_range_without_legacy_filters_behaves_as_omitted(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=")
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        total = sum(item["value"] for item in response.data)
+        self.assertEqual(total, 6)
+
+    def test_partial_date_range_start_only_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=2025-01-10,")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_partial_date_range_end_only_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=,2025-01-10")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_comma_only_date_range_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=,")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_reversed_date_range_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=2025-01-12,2025-01-10")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_reversed_legacy_from_to_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?from_date=2025-01-12&to_date=2025-01-10")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("from_date", response.data)
+        self.assertIn("to_date", response.data)
+
+    def test_bucket_gt_95_excludes_exactly_95(self):
+        container_95 = Container.objects.get(container_number=205)
+        container_95.percentage_pass = 95.0
+        container_95.percentage_reject = 5.0
+        container_95.save()
+
+        container_over_95 = Container.objects.get(container_number=204)
+        container_over_95.percentage_pass = 95.1
+        container_over_95.percentage_reject = 4.9
+        container_over_95.save()
+
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        counts = {item["name"]: item["value"] for item in response.data}
+        self.assertEqual(counts["90-95%"], 2)
+        self.assertEqual(counts["> 95%"], 1)
+
     def test_invalid_date_filters_return_400(self):
         url = reverse("quality_data:kpi-containers-by-state")
         response = self.client.get(f"{url}?from_date=10-01-2025&to_date=2025-01-31")
@@ -795,6 +913,20 @@ class ContainersByStateTest(KpiTestMixin, TestCase):
 
         self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
         self.assertIn("to_date", response.data)
+
+    def test_invalid_date_range_format_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=2025-01-10")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_invalid_date_range_value_returns_400(self):
+        url = reverse("quality_data:kpi-containers-by-state")
+        response = self.client.get(f"{url}?date_range=2025-01-10,31-01-2025")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
 
     def test_no_date_filters_preserves_legacy_behavior(self):
         url = reverse("quality_data:kpi-containers-by-state")
@@ -881,6 +1013,20 @@ class KpiFilterDateRangeTest(KpiTestMixin, TestCase):
         self.assertEqual(response.status_code, http_status.HTTP_200_OK)
         weeks = {point["x"] for s in response.data for point in s["data"]}
         self.assertEqual(weeks, {1})
+
+    def test_date_range_partial_value_returns_400_for_mixin_endpoint(self):
+        url = reverse("quality_data:kpi-aql-audited-pieces")
+        response = self.client.get(f"{url}?date_range=2025-01-10,")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
+
+    def test_date_range_reversed_bounds_returns_400_for_mixin_endpoint(self):
+        url = reverse("quality_data:kpi-aql-audited-pieces")
+        response = self.client.get(f"{url}?date_range=2025-01-11,2025-01-10")
+
+        self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
+        self.assertIn("date_range", response.data)
 
 
 class KpiFilterTeamTest(KpiTestMixin, TestCase):

--- a/backend/quality_data/tests/test_legacy.py
+++ b/backend/quality_data/tests/test_legacy.py
@@ -16,6 +16,7 @@ from quality_data.models import (
     Container,
     ContainerInspectionDefect,
 )
+from excel_importer.handler_service import bulk_insert_container
 
 
 class ColorModelTest(TestCase):
@@ -230,6 +231,54 @@ class ContainerModelTest(TestCase):
         )
 
         self.assertIsNone(container.date)
+
+    def test_legacy_reimport_invalid_date_is_recoverable_and_preserves_existing_date(self):
+        """
+        Legacy importer should treat invalid/non-parseable date as recoverable:
+        it must preserve the existing persisted date instead of crashing.
+        """
+        Container.objects.create(
+            container_number=9100,
+            customer="Legacy Recoverable Date",
+            transfer_of_container=1,
+            total_palette=50,
+            total_palette_pass=49,
+            total_palette_rejected=1,
+            percentage_pass=98.0,
+            percentage_reject=2.0,
+            date="2025-03-20",
+        )
+
+        df = pd.DataFrame([
+            {
+                "container_number": 9100,
+                "customer": "Legacy Recoverable Date",
+                "transfer_of_container": 2,
+                "total_palette": 55,
+                "total_palette_pass": 52,
+                "total_palette_rejected": 3,
+                "percentage_pass": 94.5,
+                "percentage_reject": 5.5,
+                "date": "INVALID-DATE",
+            }
+        ])
+
+        bulk_insert_container(
+            df,
+            [
+                "transfer_of_container",
+                "total_palette",
+                "total_palette_pass",
+                "total_palette_rejected",
+                "percentage_pass",
+                "percentage_reject",
+            ],
+            ["customer", "container_number", "date"],
+            defeacts_fields=[],
+        )
+
+        container = Container.objects.get(container_number=9100)
+        self.assertEqual(str(container.date), "2025-03-20")
 
 
 class ContainerDefectTypeModelTest(TestCase):

--- a/backend/quality_data/tests/test_legacy.py
+++ b/backend/quality_data/tests/test_legacy.py
@@ -202,6 +202,35 @@ class ContainerModelTest(TestCase):
         self.assertEqual(container.container_defects.count(), 1)
         self.assertEqual(defect.amount, 3)
 
+    def test_create_container_allows_null_date(self):
+        container = Container.objects.create(
+            container_number=9001,
+            customer="Date Customer",
+            transfer_of_container=1,
+            total_palette=50,
+            total_palette_pass=49,
+            total_palette_rejected=1,
+            percentage_pass=98.0,
+            percentage_reject=2.0,
+            date=None,
+        )
+
+        self.assertIsNone(container.date)
+
+    def test_container_date_defaults_to_null(self):
+        container = Container.objects.create(
+            container_number=9002,
+            customer="Default Date Customer",
+            transfer_of_container=2,
+            total_palette=60,
+            total_palette_pass=54,
+            total_palette_rejected=6,
+            percentage_pass=90.0,
+            percentage_reject=10.0,
+        )
+
+        self.assertIsNone(container.date)
+
 
 class ContainerDefectTypeModelTest(TestCase):
     def test_create_container_defect_type(self):

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -419,6 +419,63 @@ class KpiFilterMixin:
         'batch': ('batch', True),
     }
 
+    @staticmethod
+    def _parse_date_param(raw_value, field_name):
+        if raw_value is None:
+            return None
+
+        value = str(raw_value).strip()
+        if not value:
+            return None
+
+        try:
+            return datetime.date.fromisoformat(value)
+        except ValueError:
+            raise rest_framework_exceptions.ValidationError({
+                field_name: 'Invalid date. Use YYYY-MM-DD.'
+            })
+
+    @classmethod
+    def _parse_date_range_param(cls, raw_value, field_name='date_range'):
+        value = (raw_value or '').strip()
+        if not value:
+            return None, None
+
+        parts = [part.strip() for part in value.split(',')]
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise rest_framework_exceptions.ValidationError({
+                field_name: 'Invalid date_range. Use YYYY-MM-DD,YYYY-MM-DD.'
+            })
+
+        from_date = cls._parse_date_param(parts[0], field_name)
+        to_date = cls._parse_date_param(parts[1], field_name)
+        cls._validate_date_order(from_date, to_date, field_name)
+        return from_date, to_date
+
+    @staticmethod
+    def _validate_date_order(from_date, to_date, field_name='date_range'):
+        if from_date and to_date and from_date > to_date:
+            if isinstance(field_name, (tuple, list)):
+                raise rest_framework_exceptions.ValidationError({
+                    name: "Invalid date range. Start date must be on or before end date."
+                    for name in field_name
+                })
+            raise rest_framework_exceptions.ValidationError({
+                field_name: "Invalid date range. Start date must be on or before end date."
+            })
+
+    def _apply_date_range_filter(self, queryset, field_name):
+        date_range = self.request.query_params.get('date_range')
+        if date_range is None:
+            return queryset
+
+        from_date, to_date = self._parse_date_range_param(date_range, 'date_range')
+        if from_date:
+            queryset = queryset.filter(**{f'{field_name}__gte': from_date.isoformat()})
+        if to_date:
+            queryset = queryset.filter(**{f'{field_name}__lte': to_date.isoformat()})
+        return queryset
+
     def _get_filter_prefix(self, queryset):
         """
         Determine the filter prefix needed based on the queryset model.
@@ -445,15 +502,13 @@ class KpiFilterMixin:
 
         # date_range: "start_date,end_date" → date_1__gte, date_1__lte
         date_range = request.query_params.get('date_range')
-        if date_range:
-            parts = date_range.split(',')
-            if len(parts) == 2:
-                start_date, end_date = parts[0].strip(), parts[1].strip()
-                field = f'{prefix}date_1'
-                if start_date:
-                    filters[f'{field}__gte'] = start_date
-                if end_date:
-                    filters[f'{field}__lte'] = end_date
+        if date_range is not None:
+            start_date, end_date = self._parse_date_range_param(date_range, 'date_range')
+            field = f'{prefix}date_1'
+            if start_date:
+                filters[f'{field}__gte'] = start_date.isoformat()
+            if end_date:
+                filters[f'{field}__lte'] = end_date.isoformat()
 
         # week: exact integer match
         week = request.query_params.get('week')
@@ -539,7 +594,7 @@ class TopDefectsView(KpiFilterMixin, APIView):
         return Response(result, status=http_status.HTTP_200_OK)
 
 
-class FabricDefectsView(APIView):
+class FabricDefectsView(KpiFilterMixin, APIView):
     """
     GET /api/kpis/fabric-defects/
 
@@ -556,16 +611,7 @@ class FabricDefectsView(APIView):
     def get(self, request):
         queryset = SecondsGeneral.objects.all()
 
-        # Apply date filters if provided
-        date_range = request.query_params.get('date_range')
-        if date_range:
-            parts = date_range.split(',')
-            if len(parts) == 2:
-                start_date, end_date = parts[0].strip(), parts[1].strip()
-                if start_date:
-                    queryset = queryset.filter(date__gte=start_date)
-                if end_date:
-                    queryset = queryset.filter(date__lte=end_date)
+        queryset = self._apply_date_range_filter(queryset, 'date')
 
         week = request.query_params.get('week')
         if week:
@@ -718,7 +764,7 @@ class RejectedEvolutionView(KpiFilterMixin, APIView):
         return Response(result, status=http_status.HTTP_200_OK)
 
 
-class ContainersByStateView(APIView):
+class ContainersByStateView(KpiFilterMixin, APIView):
     """
     GET /api/kpis/containers-by-state/
 
@@ -740,16 +786,13 @@ class ContainersByStateView(APIView):
         if customer:
             queryset = queryset.filter(customer__exact=customer)
 
-        from_date_raw = request.query_params.get('from_date')
-        to_date_raw = request.query_params.get('to_date')
-
-        from_date, from_error = self._parse_date_param(from_date_raw, 'from_date')
-        if from_error:
-            return from_error
-
-        to_date, to_error = self._parse_date_param(to_date_raw, 'to_date')
-        if to_error:
-            return to_error
+        date_range_raw = request.query_params.get('date_range')
+        if date_range_raw is not None and date_range_raw.strip():
+            from_date, to_date = self._parse_date_range_param(date_range_raw, 'date_range')
+        else:
+            from_date = self._parse_date_param(request.query_params.get('from_date'), 'from_date')
+            to_date = self._parse_date_param(request.query_params.get('to_date'), 'to_date')
+            self._validate_date_order(from_date, to_date, ('from_date', 'to_date'))
 
         if from_date:
             queryset = queryset.filter(date__gte=from_date)
@@ -765,8 +808,8 @@ class ContainersByStateView(APIView):
                 range_bucket=Case(
                     When(percentage_pass__lt=80, then=1),
                     When(percentage_pass__gte=80, percentage_pass__lt=90, then=2),
-                    When(percentage_pass__gte=90, percentage_pass__lt=95, then=3),
-                    When(percentage_pass__gte=95, then=4),
+                    When(percentage_pass__gte=90, percentage_pass__lte=95, then=3),
+                    When(percentage_pass__gt=95, then=4),
                     output_field=IntegerField(),
                 )
             )
@@ -793,20 +836,6 @@ class ContainersByStateView(APIView):
         result = [{"name": r, "value": result_dict.get(r, 0)} for r in all_ranges]
 
         return Response(result, status=http_status.HTTP_200_OK)
-
-    @staticmethod
-    def _parse_date_param(raw_value, field_name):
-        if not raw_value:
-            return None, None
-
-        try:
-            return datetime.date.fromisoformat(raw_value), None
-        except ValueError:
-            return None, Response(
-                {field_name: "Invalid date. Use YYYY-MM-DD."},
-                status=http_status.HTTP_400_BAD_REQUEST,
-            )
-
 
 class DefectRateView(KpiFilterMixin, APIView):
     """
@@ -902,16 +931,7 @@ class KpiViewSet(KpiFilterMixin, ViewSet):
         """
         queryset = SecondsA4.objects.all()
 
-        # Apply date filters if provided
-        date_range = request.query_params.get('date_range')
-        if date_range:
-            parts = date_range.split(',')
-            if len(parts) == 2:
-                start_date, end_date = parts[0].strip(), parts[1].strip()
-                if start_date:
-                    queryset = queryset.filter(date__gte=start_date)
-                if end_date:
-                    queryset = queryset.filter(date__lte=end_date)
+        queryset = self._apply_date_range_filter(queryset, 'date')
 
         aggregated = (
             queryset

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -740,6 +740,22 @@ class ContainersByStateView(APIView):
         if customer:
             queryset = queryset.filter(customer__exact=customer)
 
+        from_date_raw = request.query_params.get('from_date')
+        to_date_raw = request.query_params.get('to_date')
+
+        from_date, from_error = self._parse_date_param(from_date_raw, 'from_date')
+        if from_error:
+            return from_error
+
+        to_date, to_error = self._parse_date_param(to_date_raw, 'to_date')
+        if to_error:
+            return to_error
+
+        if from_date:
+            queryset = queryset.filter(date__gte=from_date)
+        if to_date:
+            queryset = queryset.filter(date__lte=to_date)
+
         # Use Case/When for range grouping
         from django.db.models import IntegerField
 
@@ -777,6 +793,19 @@ class ContainersByStateView(APIView):
         result = [{"name": r, "value": result_dict.get(r, 0)} for r in all_ranges]
 
         return Response(result, status=http_status.HTTP_200_OK)
+
+    @staticmethod
+    def _parse_date_param(raw_value, field_name):
+        if not raw_value:
+            return None, None
+
+        try:
+            return datetime.date.fromisoformat(raw_value), None
+        except ValueError:
+            return None, Response(
+                {field_name: "Invalid date. Use YYYY-MM-DD."},
+                status=http_status.HTTP_400_BAD_REQUEST,
+            )
 
 
 class DefectRateView(KpiFilterMixin, APIView):


### PR DESCRIPTION
Closes #22

## Summary
- persist `Container.date` end-to-end so container imports stop dropping the business `Date` column
- carry normalized container dates through legacy import, V2 preview/confirm, and preserve existing dates on empty or invalid re-import values
- add `from_date` / `to_date` filtering to `ContainersByStateView` so container KPIs can use persisted dates

## Changes
| File | Change |
|------|--------|
| `backend/quality_data/models.py` | Added nullable indexed `Container.date` field |
| `backend/quality_data/migrations/0003_container_date.py` | Added migration for persisted container dates |
| `backend/excel_importer/date_utils.py` | Added container date normalization helper |
| `backend/excel_importer/handler_service.py` | Persisted container dates in legacy import and preserved existing dates on empty re-import |
| `backend/excel_importer/sheet_configs.py` | Mapped Excel `Date` column to `date` for Container rows |
| `backend/excel_importer/sync_service.py` | Normalized container dates in V2 preview/apply and emitted invalid-date warnings |
| `backend/quality_data/views.py` | Added `from_date` / `to_date` validation and filtering to `ContainersByStateView` |
| `backend/excel_importer/tests/test_date_utils.py` | Added tests for container date normalization |
| `backend/excel_importer/tests/test_handler_service.py` | Added tests for legacy import date persistence and preservation semantics |
| `backend/excel_importer/tests/test_sync_service.py` | Added tests for V2 preview/apply container date behavior |
| `backend/quality_data/tests/test_excel_v2_views.py` | Added API tests for preview/confirm container date flow |
| `backend/quality_data/tests/test_kpis.py` | Added KPI tests for container date filters |
| `backend/quality_data/tests/test_legacy.py` | Added compatibility tests for nullable container dates |

## Test Plan
- [x] Backend tests pass: `cd backend && pytest`
- [x] Verified import, preview/confirm, and container KPI date filtering flows through strict TDD
- [x] No shell scripts changed, so `shellcheck` is not applicable to this PR