### PR TITLE
fix(frontend): export handleApiError from axiosClient

### DIFF
--- a/frontend/src/api/axiosClient.js
+++ b/frontend/src/api/axiosClient.js
@@ -1,4 +1,4 @@
-import axios from 'axios';
+﻿import axios from 'axios';
 
 const ACCESS_TOKEN_KEY = 'rift-access-token';
 const REFRESH_TOKEN_KEY = 'rift-refresh-token';
@@ -47,6 +47,21 @@ export const tokenStorage = {
     safeStorage.remove(ACCESS_TOKEN_KEY);
     safeStorage.remove(REFRESH_TOKEN_KEY);
   },
+};
+
+export const handleApiError = (error) => {
+  const data = error.response?.data;
+  const message =
+    data?.error ||
+    data?.detail ||
+    error.message ||
+    (error.response?.status ? `Request failed: ${error.response.status}` : 'Request failed');
+
+  return {
+    message,
+    status: error.response?.status ?? null,
+    data: data ?? null,
+  };
 };
 
 axiosClient.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
This PR introduces and exports the `handleApiError` utility function within `axiosClient.js`. This function was previously missing, requiring the implementation of a centralized error handler to process API rejections consistently across the application.

---

## Changes Made
- **Created and exported** the `handleApiError` function inside `src/api/axiosClient.js`.
- Implemented the core logic to parse, format, and handle HTTP errors returned by backend endpoints.

---

## Modified Files
- src/api/axiosClient.js