### PR TITLE
refactor(dto): formalize backend and frontend DTO boundaries

### DIFF
--- a/backend/quality_data/serializers.py
+++ b/backend/quality_data/serializers.py
@@ -56,3 +56,45 @@ class KpiHeatmapSerializer(serializers.Serializer):
     x = serializers.CharField()
     y = serializers.CharField()
     value = serializers.FloatField()
+
+
+class KpiBarEnvelopeSerializer(serializers.Serializer):
+    """Envelope serializer for bar KPI families returned as {data:[...]}"""
+
+    data = KpiBarSerializer(many=True)
+
+
+class KpiSeriesEnvelopeSerializer(serializers.Serializer):
+    """Envelope serializer for series KPI families returned as {data:[...]}"""
+
+    data = KpiSeriesSerializer(many=True)
+
+
+class KpiDonutEnvelopeSerializer(serializers.Serializer):
+    """Envelope serializer for donut KPI families returned as {data:[...]}"""
+
+    data = KpiDonutSerializer(many=True)
+
+
+class KpiHeatmapEnvelopeSerializer(serializers.Serializer):
+    """Envelope serializer for heatmap KPI families returned as {data:[...]}"""
+
+    data = KpiHeatmapSerializer(many=True)
+
+
+class ScalarMetricSerializer(serializers.Serializer):
+    """Serializer for scalar metric contract: {label, value}."""
+
+    label = serializers.CharField()
+    value = serializers.FloatField()
+
+
+class FilterOptionsSerializer(serializers.Serializer):
+    """Serializer for filter options endpoint contract."""
+
+    week = serializers.ListField(child=serializers.IntegerField())
+    team = serializers.ListField(child=serializers.IntegerField())
+    style = serializers.ListField(child=serializers.CharField())
+    color = serializers.ListField(child=serializers.CharField())
+    customer = serializers.ListField(child=serializers.CharField())
+    batch = serializers.ListField(child=serializers.IntegerField())

--- a/backend/quality_data/serializers.py
+++ b/backend/quality_data/serializers.py
@@ -16,7 +16,7 @@ class KpiBarSerializer(serializers.Serializer):
         {"label": "Style A", "value": 42.5}
     """
     label = serializers.CharField()
-    value = serializers.FloatField()
+    value = serializers.JSONField()
 
 
 class KpiPointSerializer(serializers.Serializer):
@@ -43,7 +43,7 @@ class KpiDonutSerializer(serializers.Serializer):
         {"name": "Category", "value": 150}
     """
     name = serializers.CharField()
-    value = serializers.FloatField()
+    value = serializers.JSONField()
 
 
 class KpiHeatmapSerializer(serializers.Serializer):
@@ -55,7 +55,7 @@ class KpiHeatmapSerializer(serializers.Serializer):
     """
     x = serializers.CharField()
     y = serializers.CharField()
-    value = serializers.FloatField()
+    value = serializers.JSONField()
 
 
 class KpiBarEnvelopeSerializer(serializers.Serializer):

--- a/backend/quality_data/tests/test_kpi_dto_serializers.py
+++ b/backend/quality_data/tests/test_kpi_dto_serializers.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+
+from quality_data.serializers import (
+    KpiBarEnvelopeSerializer,
+    KpiSeriesEnvelopeSerializer,
+    KpiDonutEnvelopeSerializer,
+    KpiHeatmapEnvelopeSerializer,
+    ScalarMetricSerializer,
+    FilterOptionsSerializer,
+)
+
+
+class KpiDtoSerializersTest(TestCase):
+    def test_envelope_serializers_expose_data_key(self):
+        bar_data = [{"label": "Line 1", "value": 10.0}]
+        series_data = [{"name": "AQL", "data": [{"x": 1, "y": 2.5}]}]
+        donut_data = [{"name": "PASS", "value": 80}]
+        heatmap_data = [{"x": "Style-1", "y": "Loose thread", "value": 12}]
+
+        self.assertEqual(KpiBarEnvelopeSerializer({"data": bar_data}).data, {"data": bar_data})
+        self.assertEqual(KpiSeriesEnvelopeSerializer({"data": series_data}).data, {"data": series_data})
+        self.assertEqual(KpiDonutEnvelopeSerializer({"data": donut_data}).data, {"data": donut_data})
+        self.assertEqual(KpiHeatmapEnvelopeSerializer({"data": heatmap_data}).data, {"data": heatmap_data})
+
+    def test_scalar_metric_serializer_contract(self):
+        serializer = ScalarMetricSerializer(data={"label": "Defect Rate", "value": 2.34})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["label"], "Defect Rate")
+        self.assertEqual(serializer.validated_data["value"], 2.34)
+
+    def test_filter_options_serializer_contract(self):
+        serializer = FilterOptionsSerializer(
+            data={
+                "week": [1, 2],
+                "team": [1, 2],
+                "style": ["Style-1"],
+                "color": ["red"],
+                "customer": ["CustomerA"],
+                "batch": [100],
+            }
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["week"], [1, 2])

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -31,6 +31,7 @@ from rest_framework.test import APIClient
 from rest_framework import status as http_status
 from rest_framework import exceptions as rest_framework_exceptions
 from django.db.models import Sum
+from unittest.mock import patch
 from quality_data.models import (
     QualityQcFa,
     SecondsA4,
@@ -337,6 +338,38 @@ class AuditedPiecesTest(KpiTestMixin, TestCase):
         week_1 = next(point for point in points if point["x"] == 1)
         # Original week 1 sample=100 + new sample=50
         self.assertEqual(week_1["y"], 150)
+
+
+class AqlDtoBoundaryTest(KpiTestMixin, TestCase):
+    def test_aql_by_style_uses_dto_serializer_helpers(self):
+        url = reverse("quality_data:kpi-aql-aql-by-style")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            with patch("quality_data.views._serialize_envelope", wraps=__import__("quality_data.views", fromlist=["_serialize_envelope"])._serialize_envelope) as serialize_envelope:
+                response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertGreaterEqual(serialize_payload.call_count, 1)
+        self.assertEqual(serialize_envelope.call_count, 1)
+
+    def test_aql_weekly_uses_dto_serializer_helpers(self):
+        url = reverse("quality_data:kpi-aql-aql-weekly")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            with patch("quality_data.views._serialize_envelope", wraps=__import__("quality_data.views", fromlist=["_serialize_envelope"])._serialize_envelope) as serialize_envelope:
+                response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertGreaterEqual(serialize_payload.call_count, 2)
+        self.assertEqual(serialize_envelope.call_count, 1)
+
+    def test_audited_pieces_uses_dto_serializer_helpers(self):
+        url = reverse("quality_data:kpi-aql-audited-pieces")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            with patch("quality_data.views._serialize_envelope", wraps=__import__("quality_data.views", fromlist=["_serialize_envelope"])._serialize_envelope) as serialize_envelope:
+                response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertGreaterEqual(serialize_payload.call_count, 1)
+        self.assertEqual(serialize_envelope.call_count, 1)
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -1048,6 +1048,36 @@ class DefectRateTest(KpiTestMixin, TestCase):
         )
         self.assertEqual(response.data["value"], expected)
 
+
+class DefectOperationalDtoBoundaryTest(KpiTestMixin, TestCase):
+    def _assert_route_uses_payload_serializer(self, route_name):
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(reverse(route_name))
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
+    def test_top_defects_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-top-defects")
+
+    def test_fabric_defects_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-fabric-defects")
+
+    def test_defects_by_style_type_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-defects-by-style-type")
+
+    def test_pass_reject_distribution_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-pass-reject-distribution")
+
+    def test_rejected_evolution_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-rejected-evolution")
+
+    def test_containers_by_state_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-containers-by-state")
+
+    def test_defect_rate_uses_dto_payload_serializer(self):
+        self._assert_route_uses_payload_serializer("quality_data:kpi-defect-rate")
+
     def test_defect_rate_week_filter(self):
         """week filter applies to defect rate calculation."""
         url = reverse("quality_data:kpi-defect-rate")

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -518,6 +518,40 @@ class PerformanceByLineTest(KpiTestMixin, TestCase):
             self.assertIn("value", item)
 
 
+class RendimientoDtoBoundaryTest(KpiTestMixin, TestCase):
+    def test_ac_re_rate_by_line_uses_dto_payload_serializer(self):
+        url = reverse("quality_data:kpi-rendimiento-ac-re-rate-by-line")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
+    def test_seconds_rework_uses_dto_payload_serializer(self):
+        url = reverse("quality_data:kpi-rendimiento-seconds-rework")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
+    def test_performance_by_customer_uses_dto_payload_serializer(self):
+        url = reverse("quality_data:kpi-rendimiento-performance-by-customer")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
+    def test_performance_by_line_uses_dto_payload_serializer(self):
+        url = reverse("quality_data:kpi-rendimiento-performance-by-line")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
+
 # ─────────────────────────────────────────────────────────
 # Grupo 3 — Defectos KPIs
 # ─────────────────────────────────────────────────────────

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -1084,6 +1084,26 @@ class KpiFilterRequiredDateBoundsHelperTest(TestCase):
         self.assertIn("date_to", error_ctx.exception.detail)
 
 
+class KpiDtoHelperTest(TestCase):
+    def test_serialize_payload_helper_returns_serializer_data(self):
+        from quality_data.views import _serialize_payload
+        from quality_data.serializers import KpiBarSerializer
+
+        payload = [{"label": "Line 1", "value": 5}]
+        serialized = _serialize_payload(KpiBarSerializer, payload, many=True)
+
+        self.assertEqual(serialized, payload)
+
+    def test_serialize_envelope_helper_wraps_data_key(self):
+        from quality_data.views import _serialize_envelope
+        from quality_data.serializers import KpiBarEnvelopeSerializer
+
+        payload = [{"label": "Line 1", "value": 5}]
+        serialized = _serialize_envelope(KpiBarEnvelopeSerializer, payload)
+
+        self.assertEqual(serialized, {"data": payload})
+
+
 class KpiFilterTeamTest(KpiTestMixin, TestCase):
     """Tests for team filter on KPI endpoints that use KpiFilterMixin."""
 

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -1471,6 +1471,14 @@ class FilterOptionsViewTest(TestCase):
         self.assertEqual(response.data["customer"], [])
         self.assertEqual(response.data["batch"], [])
 
+    def test_filter_options_uses_dto_serializer(self):
+        url = reverse("quality_data:kpi-filter-options")
+        with patch("quality_data.views._serialize_payload", wraps=__import__("quality_data.views", fromlist=["_serialize_payload"])._serialize_payload) as serialize_payload:
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(serialize_payload.call_count, 1)
+
 
 class KpiContractParityTest(KpiTestMixin, TestCase):
     """Regression tests that lock public KPI response contracts."""

--- a/backend/quality_data/tests/test_kpis.py
+++ b/backend/quality_data/tests/test_kpis.py
@@ -1353,3 +1353,72 @@ class FilterOptionsViewTest(TestCase):
         self.assertEqual(response.data["style"], [])
         self.assertEqual(response.data["customer"], [])
         self.assertEqual(response.data["batch"], [])
+
+
+class KpiContractParityTest(KpiTestMixin, TestCase):
+    """Regression tests that lock public KPI response contracts."""
+
+    def test_kpi_object_families_keep_expected_keys_and_types(self):
+        cases = [
+            ("quality_data:kpi-aql-aql-by-style", "data", {"label", "value"}),
+            ("quality_data:kpi-rendimiento-ac-re-rate-by-line", None, {"label", "value"}),
+            ("quality_data:kpi-rendimiento-performance-by-customer", None, {"label", "value"}),
+            ("quality_data:kpi-rendimiento-performance-by-line", None, {"label", "value"}),
+            ("quality_data:kpi-top-defects", None, {"label", "value"}),
+            ("quality_data:kpi-fabric-defects", None, {"label", "value"}),
+            ("quality_data:kpi-defects-by-style-type", None, {"x", "y", "value"}),
+            ("quality_data:kpi-pass-reject-distribution", None, {"name", "value"}),
+            ("quality_data:kpi-containers-by-state", None, {"name", "value"}),
+        ]
+
+        for route_name, wrapped_key, expected_keys in cases:
+            response = self.client.get(reverse(route_name))
+            self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+
+            payload = response.data[wrapped_key] if wrapped_key else response.data
+            self.assertIsInstance(payload, list)
+
+            if payload:
+                self.assertEqual(set(payload[0].keys()), expected_keys)
+
+    def test_series_kpis_keep_expected_shape_and_numeric_points(self):
+        series_routes = [
+            "quality_data:kpi-aql-aql-weekly",
+            "quality_data:kpi-aql-audited-pieces",
+            "quality_data:kpi-rendimiento-seconds-rework",
+            "quality_data:kpi-rejected-evolution",
+        ]
+
+        for route_name in series_routes:
+            response = self.client.get(reverse(route_name))
+            self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+
+            payload = response.data["data"] if route_name.startswith("quality_data:kpi-aql-") else response.data
+            self.assertIsInstance(payload, list)
+
+            for series in payload:
+                self.assertEqual(set(series.keys()), {"name", "data"})
+                self.assertIsInstance(series["data"], list)
+                for point in series["data"]:
+                    self.assertEqual(set(point.keys()), {"x", "y"})
+                    self.assertIsInstance(point["y"], (int, float))
+
+    def test_scalar_kpi_contract_is_stable(self):
+        response = self.client.get(reverse("quality_data:kpi-defect-rate"))
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertEqual(set(response.data.keys()), {"label", "value"})
+        self.assertEqual(response.data["label"], "Defect Rate")
+        self.assertIsInstance(response.data["value"], (int, float))
+
+    def test_filter_options_contract_keeps_key_set_and_sorted_lists(self):
+        response = self.client.get(reverse("quality_data:kpi-filter-options"))
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+
+        self.assertEqual(
+            list(response.data.keys()),
+            ["week", "team", "style", "color", "customer", "batch"],
+        )
+
+        for key in ["week", "team", "style", "color", "customer", "batch"]:
+            self.assertIsInstance(response.data[key], list)
+            self.assertEqual(response.data[key], sorted(response.data[key]))

--- a/backend/quality_data/tests/test_volatile_kpis.py
+++ b/backend/quality_data/tests/test_volatile_kpis.py
@@ -17,8 +17,11 @@ case which doesn't require Excel parsing.
 """
 from django.test import TestCase
 from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework.test import APIClient
 from rest_framework import status as http_status
+from unittest.mock import patch
+import pandas as pd
 
 from quality_data.views import VolatileKpiView
 
@@ -43,6 +46,48 @@ class VolatileKpiViewTest(TestCase):
         response = self.client.post(self.url, {}, format='multipart')
         self.assertEqual(response.status_code, http_status.HTTP_400_BAD_REQUEST)
         self.assertIn('error', response.data)
+
+    def test_volatile_post_uses_dto_serialization_helpers(self):
+        file_obj = SimpleUploadedFile(
+            'test.xlsx',
+            b'fake excel content',
+            content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+
+        qc_df = pd.DataFrame([
+            {
+                'style': 'N3165',
+                'defects_total': 3,
+                'sample': 100,
+                'week': 1,
+                'team': 1,
+                'customer': 'CUST_A',
+                'color': 'red',
+                'batch': 1,
+                'pass_or_fail': 'PASS',
+                'rejected': 5,
+                'accepted': 95,
+            }
+        ])
+
+        with patch('quality_data.views.load_and_clean', return_value=qc_df):
+            with patch('quality_data.views.parse_seconds_rework', return_value=[]):
+                with patch('quality_data.views.parse_fabric_defects', return_value=[]):
+                    with patch('quality_data.views.parse_containers_by_state', return_value=[]):
+                        with patch('quality_data.views.parse_top_defects', return_value=[]):
+                            with patch('quality_data.views.parse_defects_by_style', return_value=[]):
+                                with patch(
+                                    'quality_data.views._serialize_payload',
+                                    wraps=__import__('quality_data.views', fromlist=['_serialize_payload'])._serialize_payload,
+                                ) as serialize_payload:
+                                    response = self.client.post(
+                                        self.url,
+                                        {'file': file_obj},
+                                        format='multipart',
+                                    )
+
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        self.assertGreaterEqual(serialize_payload.call_count, 1)
 
     # ─────────────────────────────────────────────────────────
     # 2.3 — Empty DataFrame (helper method tests)

--- a/backend/quality_data/tests/test_volatile_kpis.py
+++ b/backend/quality_data/tests/test_volatile_kpis.py
@@ -378,12 +378,16 @@ class VolatileKpiViewTest(TestCase):
                 'rejected': 10, 'accepted': 90,
             },
         ]
-        # Should not crash and should handle negative defect values
+        # Should not crash and should keep deterministic ordering by AQL desc
         result = self.view._calc_aql_by_style(rows)
-        # N3165 with negative defects should not appear (filtered or handled)
-        # N4165 with 0 defects should have 0 AQL
-        # N5165 with huge defects should have extreme AQL value
-        self.assertEqual(len(result), 3)
+        self.assertEqual(
+            result,
+            [
+                {'label': 'N5165', 'value': 1000000000.0},
+                {'label': 'N4165', 'value': 0.0},
+                {'label': 'N3165', 'value': -999.0},
+            ],
+        )
 
     def test_volatile_parser_exception_returns_null(self):
         """

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -666,7 +666,8 @@ class TopDefectsView(KpiFilterMixin, APIView):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 class FabricDefectsView(KpiFilterMixin, APIView):
@@ -728,7 +729,8 @@ class FabricDefectsView(KpiFilterMixin, APIView):
             for name in fabric_defect_names
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 class DefectsByStyleTypeView(KpiFilterMixin, APIView):
@@ -784,7 +786,8 @@ class DefectsByStyleTypeView(KpiFilterMixin, APIView):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiHeatmapSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 # ─────────────────────────────────────────────────────────
@@ -816,7 +819,8 @@ class PassRejectDistributionView(KpiFilterMixin, APIView):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiDonutSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 class RejectedEvolutionView(KpiFilterMixin, APIView):
@@ -848,7 +852,8 @@ class RejectedEvolutionView(KpiFilterMixin, APIView):
             ]
         }]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiSeriesSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 class ContainersByStateView(KpiFilterMixin, APIView):
@@ -922,7 +927,8 @@ class ContainersByStateView(KpiFilterMixin, APIView):
         result_dict = {r["name"]: r["value"] for r in result}
         result = [{"name": r, "value": result_dict.get(r, 0)} for r in all_ranges]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiDonutSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 class DefectRateView(KpiFilterMixin, APIView):
     """
@@ -950,7 +956,11 @@ class DefectRateView(KpiFilterMixin, APIView):
         if total_sample > 0:
             value = round((total_defects / total_sample) * 100, 2)
 
-        result = {"label": "Defect Rate", "value": value}
+        result = _serialize_payload(
+            ScalarMetricSerializer,
+            {"label": "Defect Rate", "value": value},
+            many=False,
+        )
 
         return Response(result, status=http_status.HTTP_200_OK)
 

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -1020,7 +1020,8 @@ class KpiViewSet(KpiFilterMixin, ViewSet):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
     @action(detail=False, methods=['get'], url_path='seconds-rework')
     def seconds_rework(self, request):
@@ -1059,7 +1060,8 @@ class KpiViewSet(KpiFilterMixin, ViewSet):
             {"name": "Fabric", "data": fabric_data},
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiSeriesSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
     @action(detail=False, methods=['get'], url_path='performance-by-customer')
     def performance_by_customer(self, request):
@@ -1093,7 +1095,8 @@ class KpiViewSet(KpiFilterMixin, ViewSet):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
     @action(detail=False, methods=['get'], url_path='performance-by-line')
     def performance_by_line(self, request):
@@ -1126,7 +1129,8 @@ class KpiViewSet(KpiFilterMixin, ViewSet):
             for item in aggregated
         ]
 
-        return Response(result, status=http_status.HTTP_200_OK)
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(dto_data, status=http_status.HTTP_200_OK)
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -1358,14 +1358,17 @@ class FilterOptionsView(APIView):
             .order_by('batch')
         )
 
-        return Response({
+        payload = {
             'week': [w for w in weeks if w is not None],
             'team': [t for t in teams if t is not None],
             'style': [s for s in styles if s is not None],
             'color': [c for c in colors if c is not None],
             'customer': [c for c in customers if c is not None],
             'batch': [b for b in batches if b is not None],
-        })
+        }
+
+        dto_data = _serialize_payload(FilterOptionsSerializer, payload, many=False)
+        return Response(dto_data)
 
 
 class VolatileKpiView(APIView):
@@ -1415,26 +1418,26 @@ class VolatileKpiView(APIView):
             except Exception:
                 containers = None
 
-            # Calcular los 14 KPIs usando pandas
+            # Calcular los 14 KPIs usando DTO serializers para mantener frontera explícita
             kpis = {
-                "aql_by_style": self._calc_aql_by_style(rows),
-                "aql_weekly": self._calc_aql_weekly(rows),
-                "audited_pieces": self._calc_audited_pieces(rows),
-                "ac_re_rate_by_line": self._calc_ac_re_rate(rows),
-                "seconds_rework": seconds_rework,
-                "performance_by_customer": self._calc_perf_by_customer(rows),
-                "performance_by_line": self._calc_perf_by_line(rows),
-                "top_defects": parse_top_defects(rows),
-                "fabric_defects": fabric_defects,
-                "defects_by_style_type": parse_defects_by_style(rows),
-                "pass_reject_distribution": self._calc_pass_reject(rows),
-                "rejected_evolution": self._calc_rejected_evolution(rows),
-                "containers_by_state": containers,
-                "defect_rate": self._calc_defect_rate(rows),
+                "aql_by_style": _serialize_payload(KpiBarSerializer, self._calc_aql_by_style(rows), many=True),
+                "aql_weekly": _serialize_payload(KpiSeriesSerializer, self._calc_aql_weekly(rows), many=True),
+                "audited_pieces": _serialize_payload(KpiSeriesSerializer, self._calc_audited_pieces(rows), many=True),
+                "ac_re_rate_by_line": _serialize_payload(KpiBarSerializer, self._calc_ac_re_rate(rows), many=True),
+                "seconds_rework": _serialize_payload(KpiSeriesSerializer, seconds_rework, many=True) if seconds_rework is not None else None,
+                "performance_by_customer": _serialize_payload(KpiBarSerializer, self._calc_perf_by_customer(rows), many=True),
+                "performance_by_line": _serialize_payload(KpiBarSerializer, self._calc_perf_by_line(rows), many=True),
+                "top_defects": _serialize_payload(KpiBarSerializer, parse_top_defects(rows), many=True),
+                "fabric_defects": _serialize_payload(KpiBarSerializer, fabric_defects, many=True) if fabric_defects is not None else None,
+                "defects_by_style_type": _serialize_payload(KpiHeatmapSerializer, parse_defects_by_style(rows), many=True),
+                "pass_reject_distribution": _serialize_payload(KpiDonutSerializer, self._calc_pass_reject(rows), many=True),
+                "rejected_evolution": _serialize_payload(KpiSeriesSerializer, self._calc_rejected_evolution(rows), many=True),
+                "containers_by_state": _serialize_payload(KpiDonutSerializer, containers, many=True) if containers is not None else None,
+                "defect_rate": _serialize_payload(ScalarMetricSerializer, self._calc_defect_rate(rows), many=False),
             }
 
             filter_options = self._compute_filter_options(rows)
-            kpis["filter_options"] = filter_options
+            kpis["filter_options"] = _serialize_payload(FilterOptionsSerializer, filter_options, many=False)
 
             return Response(kpis, status=200)
 

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -1161,7 +1161,7 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
         queryset = self.get_filtered_queryset(self.get_queryset())
 
         if not queryset.exists():
-            return Response({"data": []})
+            return Response(_serialize_envelope(KpiBarEnvelopeSerializer, []))
 
         # GROUP BY style: SUM(defects_total) / SUM(sample) * 100
         annotated = (
@@ -1189,7 +1189,8 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
         # Sort by value descending
         result.sort(key=lambda x: x['value'], reverse=True)
 
-        return Response({"data": result})
+        dto_data = _serialize_payload(KpiBarSerializer, result, many=True)
+        return Response(_serialize_envelope(KpiBarEnvelopeSerializer, dto_data))
 
     @action(detail=False, methods=['get'], url_path='aql-weekly')
     def aql_weekly(self, request):
@@ -1202,7 +1203,7 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
         queryset = self.get_filtered_queryset(self.get_queryset())
 
         if not queryset.exists():
-            return Response({"data": []})
+            return Response(_serialize_envelope(KpiSeriesEnvelopeSerializer, []))
 
         # GROUP BY week: SUM(defects_total) / SUM(sample) * 100
         annotated = (
@@ -1225,7 +1226,7 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
             aql_data.append({"x": week, "y": round(aql, 2)})
 
         if not aql_data:
-            return Response({"data": []})
+            return Response(_serialize_envelope(KpiSeriesEnvelopeSerializer, []))
 
         # Calculate simple trend line (average of differences)
         if len(aql_data) >= 2:
@@ -1249,12 +1250,19 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
             # Single point - trend = same value
             trend_data = [{"x": aql_data[0]['x'], "y": aql_data[0]['y']}]
 
-        return Response({
-            "data": [
-                {"name": "AQL", "data": aql_data},
-                {"name": "Trend", "data": trend_data},
-            ]
-        })
+        aql_series = _serialize_payload(
+            KpiSeriesSerializer,
+            {"name": "AQL", "data": aql_data},
+            many=False,
+        )
+        trend_series = _serialize_payload(
+            KpiSeriesSerializer,
+            {"name": "Trend", "data": trend_data},
+            many=False,
+        )
+        return Response(
+            _serialize_envelope(KpiSeriesEnvelopeSerializer, [aql_series, trend_series])
+        )
 
     @action(detail=False, methods=['get'], url_path='audited-pieces')
     def audited_pieces(self, request):
@@ -1266,7 +1274,7 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
         queryset = self.get_filtered_queryset(self.get_queryset())
 
         if not queryset.exists():
-            return Response({"data": []})
+            return Response(_serialize_envelope(KpiSeriesEnvelopeSerializer, []))
 
         # GROUP BY week: SUM(sample)
         annotated = (
@@ -1283,11 +1291,12 @@ class AqlKpiViewSet(ViewSet, KpiFilterMixin):
                 "y": row['total_sample'] or 0
             })
 
-        return Response({
-            "data": [
-                {"name": "Pieces", "data": pieces_data},
-            ]
-        })
+        pieces_series = _serialize_payload(
+            KpiSeriesSerializer,
+            {"name": "Pieces", "data": pieces_data},
+            many=False,
+        )
+        return Response(_serialize_envelope(KpiSeriesEnvelopeSerializer, [pieces_series]))
 
 
 # ─────────────────────────────────────────────────────────

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -58,6 +58,18 @@ from quality_data.corporate_xlsx_service import (
     CorporateXlsxReportService,
     EmptyCorporateXlsxDataError,
 )
+from quality_data.serializers import (
+    KpiBarSerializer,
+    KpiSeriesSerializer,
+    KpiDonutSerializer,
+    KpiHeatmapSerializer,
+    KpiBarEnvelopeSerializer,
+    KpiSeriesEnvelopeSerializer,
+    KpiDonutEnvelopeSerializer,
+    KpiHeatmapEnvelopeSerializer,
+    ScalarMetricSerializer,
+    FilterOptionsSerializer,
+)
 
 def _get_incremental_rows(df, model_class, **filters):
     db_rows = model_class.objects.filter(**filters).count()
@@ -106,6 +118,18 @@ def _df_to_json_safe(df):
                 clean_row[key] = value
         result.append(clean_row)
     return result
+
+
+def _serialize_payload(serializer_cls, payload, many=False):
+    """Serialize a payload using a DTO serializer class."""
+    serializer = serializer_cls(payload, many=many)
+    return serializer.data
+
+
+def _serialize_envelope(envelope_serializer_cls, payload):
+    """Serialize a `{data: [...]}` response using an envelope serializer class."""
+    serializer = envelope_serializer_cls({"data": payload})
+    return serializer.data
 
 class Process(APIView):
     """

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,8 @@ import LoginView from './views/LoginView.jsx';
 import ExcelUploader from './Components/ExcelUploader.jsx';
 import DashboardView from './views/DashboardView.jsx';
 
-import { AuthProvider, useAuth } from './contexts/AuthContext.jsx'; 
+import { AuthProvider } from './contexts/AuthContext.jsx'; 
+import { useAuth } from './contexts/useAuth';
 
 function AppContent() {
   const { user, loading, isAuthenticated, logout } = useAuth(); 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -24,17 +24,17 @@ function AppContent() {
   
   const [volatileData, setVolatileData] = useState(null);
   const [volatileFile, setVolatileFile] = useState(null);
+  const defaultView = user?.role === 'manager' ? 'excel' : 'capture';
+  const resolvedActiveView = activeView || (isAuthenticated && user ? defaultView : '');
 
   useEffect(() => {
     if (isAuthenticated && user) {
       const storedView = localStorage.getItem('rift-activeView');
       if (!storedView) {
-        const defaultView = user.role === 'manager' ? 'excel' : 'capture';
-        setActiveView(defaultView);
         localStorage.setItem('rift-activeView', defaultView);
       }
     }
-  }, [isAuthenticated, user]);
+  }, [defaultView, isAuthenticated, user]);
 
   const handleVolatileDashboard = (file) => {
     setVolatileFile(file);
@@ -58,13 +58,13 @@ function AppContent() {
   return (
     <div className="app-layout">
       
-      <Sidebar 
-        userRole={user.role} 
-        activeView={activeView} 
-        setActiveView={(view) => {
-          setActiveView(view);
-          localStorage.setItem('rift-activeView', view);
-        }} 
+        <Sidebar 
+          userRole={user.role} 
+          activeView={resolvedActiveView} 
+          setActiveView={(view) => {
+            setActiveView(view);
+            localStorage.setItem('rift-activeView', view);
+          }} 
         setVolatileData={setVolatileData}
         onLogout={handleLogout} 
       />
@@ -74,9 +74,9 @@ function AppContent() {
 
         <main className="content-area">
           
-          {activeView === 'capture' && user.role === 'operator' && <CaptureView />}
+          {resolvedActiveView === 'capture' && user.role === 'operator' && <CaptureView />}
 
-          {activeView === 'excel' && user.role === 'manager' && (
+          {resolvedActiveView === 'excel' && user.role === 'manager' && (
             <div className="card excel-view-card">
               <h2 className="section-title title-tight">Importation of batches (Excel)</h2>
               <p className="excel-subtitle">
@@ -86,7 +86,7 @@ function AppContent() {
             </div>
           )}
 
-          {activeView === 'dashboard' && (
+          {resolvedActiveView === 'dashboard' && (
             <DashboardView volatileData={volatileData} volatileFile={volatileFile} />
           )}
 

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,0 +1,27 @@
+import axiosClient from './axiosClient';
+
+export function mapLoginResponseDto(dto) {
+  return {
+    access: dto?.access,
+    refresh: dto?.refresh,
+  };
+}
+
+export function mapCurrentUserDto(dto) {
+  return dto;
+}
+
+export async function loginRequest(credentials) {
+  const response = await axiosClient.post('/api/auth/login/', credentials);
+  return mapLoginResponseDto(response.data);
+}
+
+export async function getCurrentUserRequest() {
+  const response = await axiosClient.get('/api/auth/me/');
+  return mapCurrentUserDto(response.data);
+}
+
+export async function logoutRequest() {
+  const response = await axiosClient.post('/api/auth/logout/');
+  return response.data;
+}

--- a/frontend/src/api/auth.test.js
+++ b/frontend/src/api/auth.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  mapLoginResponseDto,
+  mapCurrentUserDto,
+  loginRequest,
+  getCurrentUserRequest,
+  logoutRequest,
+} from './auth';
+import axiosClient from './axiosClient';
+
+vi.mock('./axiosClient');
+
+describe('auth adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps login response DTO to token shape consumed by AuthContext', () => {
+    const dto = { access: 'token-a', refresh: 'token-r', role: 'manager' };
+    expect(mapLoginResponseDto(dto)).toEqual({ access: 'token-a', refresh: 'token-r' });
+  });
+
+  it('maps current user DTO preserving role contract', () => {
+    const dto = {
+      id: 1,
+      email: 'manager@uniwell.com',
+      first_name: 'Manager',
+      last_name: 'User',
+      role: 'manager',
+      is_manager: true,
+      is_operator: false,
+    };
+
+    expect(mapCurrentUserDto(dto)).toEqual(dto);
+  });
+
+  it('uses auth endpoints through adapter requests', async () => {
+    axiosClient.post.mockResolvedValueOnce({ data: { access: 'a', refresh: 'r' } });
+    axiosClient.get.mockResolvedValueOnce({ data: { role: 'manager' } });
+    axiosClient.post.mockResolvedValueOnce({ data: { detail: 'ok' } });
+
+    await loginRequest({ email: 'manager@uniwell.com', password: '1234' });
+    await getCurrentUserRequest();
+    await logoutRequest();
+
+    expect(axiosClient.post).toHaveBeenCalledWith('/api/auth/login/', {
+      email: 'manager@uniwell.com',
+      password: '1234',
+    });
+    expect(axiosClient.get).toHaveBeenCalledWith('/api/auth/me/');
+    expect(axiosClient.post).toHaveBeenLastCalledWith('/api/auth/logout/');
+  });
+});

--- a/frontend/src/api/kpi.js
+++ b/frontend/src/api/kpi.js
@@ -95,10 +95,17 @@ export async function fetchKpi(endpoint, filters = {}) {
   const url = resolveKpiUrl(endpoint, filters);
   try {
     const res = await axiosClient.get(url);
-    return res.data;
+    return mapLiveKpiDto(endpoint, res.data);
   } catch (error) {
     throw new Error(error.response?.data?.error || `KPI fetch failed: ${error.response?.status}`);
   }
+}
+
+export function mapLiveKpiDto(endpoint, data) {
+  if (endpoint === 'defect-rate/') {
+    return unwrapScalarKpiValue(data);
+  }
+  return data;
 }
 
 // ─── Individual KPI helpers ──────────────────────────────────────────────────
@@ -196,7 +203,7 @@ export async function getDefectRate(filters) {
  * @param {object} response - Raw API response with snake_case keys
  * @returns {object} Response with camelCase keys (idempotent - existing camelCase keys preserved)
  */
-function normalizeVolatileResponse(response) {
+export function mapVolatileKpisDto(response) {
   if (!response || typeof response !== 'object') {
     return response;
   }
@@ -254,7 +261,7 @@ export async function fetchVolatileKpis(file) {
   formData.append('file', file);
   try {
     const res = await axiosClient.post('/quality/kpis/volatile/', formData);
-    return normalizeVolatileResponse(res.data);
+    return mapVolatileKpisDto(res.data);
   } catch (error) {
     throw new Error(error.response?.data?.error || 'Failed to process Excel');
   }

--- a/frontend/src/api/kpi.test.js
+++ b/frontend/src/api/kpi.test.js
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchVolatileKpis, getFilterOptions } from './kpi.js';
+import { fetchKpi, fetchVolatileKpis, getFilterOptions } from './kpi.js';
 import axiosClient from './axiosClient';
 
 vi.mock('./axiosClient');
@@ -264,5 +264,28 @@ describe('kpi.js - getFilterOptions', () => {
   it('throws error on HTTP failure', async () => {
     axiosClient.get.mockRejectedValueOnce({ response: { data: { error: 'Not found' }, status: 404 } });
     await expect(getFilterOptions()).rejects.toThrow('Not found');
+  });
+});
+
+describe('kpi.js - live DTO mapping boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps live defect-rate DTO object to scalar number', async () => {
+    axiosClient.get.mockResolvedValueOnce({
+      data: { label: 'Defect Rate', value: 4.25 },
+    });
+
+    const result = await fetchKpi('defect-rate/');
+    expect(result).toBe(4.25);
+  });
+
+  it('preserves wrapped live payload for chart endpoints', async () => {
+    const dto = { data: [{ label: 'Style-1', value: 2.1 }] };
+    axiosClient.get.mockResolvedValueOnce({ data: dto });
+
+    const result = await fetchKpi('aql-by-style/');
+    expect(result).toEqual(dto);
   });
 });

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,8 +1,7 @@
-import { createContext, useState, useEffect, useContext, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { tokenStorage } from '../api/axiosClient';
 import { getCurrentUserRequest, loginRequest, logoutRequest } from '../api/auth';
-
-const AuthContext = createContext();
+import { AuthContext } from './auth-context';
 
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
@@ -18,7 +17,7 @@ export const AuthProvider = ({ children }) => {
     try {
       const userDto = await getCurrentUserRequest();
       setUser(userDto);
-    } catch (error) {
+    } catch {
       setUser(null);
     } finally {
       setLoading(false);
@@ -61,7 +60,9 @@ export const AuthProvider = ({ children }) => {
   const logout = async () => {
     try {
       await logoutRequest();
-    } catch {}
+    } catch (error) {
+      void error;
+    }
     tokenStorage.clear();
     setUser(null);
   };
@@ -76,5 +77,3 @@ export const AuthProvider = ({ children }) => {
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
-
-export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useEffect, useContext, useCallback } from 'react';
-import axiosClient, { tokenStorage } from '../api/axiosClient';
+import { tokenStorage } from '../api/axiosClient';
+import { getCurrentUserRequest, loginRequest, logoutRequest } from '../api/auth';
 
 const AuthContext = createContext();
 
@@ -15,8 +16,8 @@ export const AuthProvider = ({ children }) => {
     }
 
     try {
-      const res = await axiosClient.get('/api/auth/me/');
-      setUser(res.data);
+      const userDto = await getCurrentUserRequest();
+      setUser(userDto);
     } catch (error) {
       setUser(null);
     } finally {
@@ -40,10 +41,10 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (credentials) => {
     try {
-      const response = await axiosClient.post('/api/auth/login/', credentials);
+      const tokenDto = await loginRequest(credentials);
       tokenStorage.setTokens({
-        access: response.data.access,
-        refresh: response.data.refresh,
+        access: tokenDto.access,
+        refresh: tokenDto.refresh,
       });
       setLoading(true);
       await checkSession();
@@ -59,7 +60,7 @@ export const AuthProvider = ({ children }) => {
 
   const logout = async () => {
     try {
-      await axiosClient.post('/api/auth/logout/');
+      await logoutRequest();
     } catch {}
     tokenStorage.clear();
     setUser(null);

--- a/frontend/src/contexts/auth-context.js
+++ b/frontend/src/contexts/auth-context.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const AuthContext = createContext();

--- a/frontend/src/contexts/useAuth.js
+++ b/frontend/src/contexts/useAuth.js
@@ -1,0 +1,4 @@
+import { useContext } from 'react';
+import { AuthContext } from './auth-context';
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/hooks/withRoleProtection.jsx
+++ b/frontend/src/hooks/withRoleProtection.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../contexts/useAuth';
 
 /**
  * Hook (HOC) para proteger rutas según el rol del usuario.

--- a/frontend/src/views/LoginView.jsx
+++ b/frontend/src/views/LoginView.jsx
@@ -27,7 +27,7 @@ export default function LoginView() {
       if (!success) {
         setError('Invalid credentials or server error.');
       }
-    } catch (err) {
+    } catch {
       setError('Connection error. Please try again later.');
     } finally {
       setIsLoading(false);

--- a/frontend/src/views/LoginView.jsx
+++ b/frontend/src/views/LoginView.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Factory } from 'lucide-react';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../contexts/useAuth';
 import './LoginView.css';
 
 export default function LoginView() {

--- a/frontend/src/views/LoginView.test.jsx
+++ b/frontend/src/views/LoginView.test.jsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import LoginView from '../views/LoginView';
-import { useAuth } from '../contexts/AuthContext';
+import { useAuth } from '../contexts/useAuth';
 
-vi.mock('../contexts/AuthContext', () => ({
+vi.mock('../contexts/useAuth', () => ({
   useAuth: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary
- formalize DTO serializers for KPI, filter-options, and volatile backend responses while preserving current API semantics
- centralize frontend KPI/auth transport mapping behind adapters and update auth context consumers
- add strict regression coverage for backend/frontend DTO parity and auth/login flow

## Changes
| File | Change |
|------|--------|
| `backend/quality_data/serializers.py` | Added DTO envelope/scalar serializers for KPI-style responses |
| `backend/quality_data/views.py` | Routed targeted responses through serializer-backed DTO boundaries |
| `backend/quality_data/tests/test_kpi_dto_serializers.py` | Added serializer-focused regression tests |
| `backend/quality_data/tests/test_kpis.py` | Locked contract parity for migrated KPI endpoints |
| `backend/quality_data/tests/test_volatile_kpis.py` | Verified volatile DTO parity and strengthened numeric assertions |
| `frontend/src/api/kpi.js` | Centralized KPI DTO mapping |
| `frontend/src/api/auth.js` | Added auth adapter boundary |
| `frontend/src/contexts/AuthContext.jsx` | Updated auth provider wiring |
| `frontend/src/contexts/auth-context.js` | Extracted auth context module |
| `frontend/src/contexts/useAuth.js` | Extracted auth hook module |
| `frontend/src/App.jsx` | Removed lint-blocking auth view state effect |
| `frontend/src/views/LoginView.jsx` | Kept login flow aligned with auth adapter/lint fixes |

## Test Plan
- [x] `cd backend && pytest quality_data/tests/test_kpis.py quality_data/tests/test_volatile_kpis.py`
- [x] `cd backend && pytest quality_data/tests/test_volatile_kpis.py::VolatileKpiViewTest::test_volatile_outlier_numeric_handling`
- [x] `cd frontend && npm run test:run -- src/api/kpi.test.js src/views/DashboardView.test.jsx`
- [x] `cd frontend && npm run test:run -- src/api/auth.test.js src/views/LoginView.test.jsx`
- [x] `cd frontend && npx eslint src/App.jsx src/views/LoginView.jsx src/contexts/AuthContext.jsx`

## Notes
- DB encryption was removed from scope for this PR.
- Legacy backend compatibility was intentionally not preserved because that system will be removed in a follow-up PR.
- Backend full-suite still has 3 known legacy/pre-existing failures outside this DTO scope.