### PR TITLE
refactor(backend): expand inspection bridge to QualityQcFa, SecondsGeneral, and SecondsA4

### DIFF
--- a/backend/media_data/inspection_bridge.py
+++ b/backend/media_data/inspection_bridge.py
@@ -2,9 +2,11 @@
 Inspection Bridge — Connect media_data inspections to quality_data tables.
 
 When a tactile inspection is closed, this service:
-1. Looks up the corresponding QualityQcFa record by style + color
+1. Finds matching records across QualityQcFa, SecondsGeneral, SecondsA4
+   by style + color + week
 2. Updates accepted/rejected/defects_total based on captured defects
 3. Syncs RevisionDefect records into InspectionDefect (through table)
+4. Populates common fields (style, color, week, date, size) on Seconds tables
 
 This bridges the gap between the touch capture interface (media_data)
 and the QC reporting tables (quality_data).
@@ -15,34 +17,44 @@ from quality_data.models import (
     QualityQcFa,
     InspectionDefect,
     DefectType,
+    SecondsGeneral,
+    SecondsA4,
 )
 from media_data.models import InspectionData, RevisionDefect
 
 
 def bridge_inspection(inspection: InspectionData) -> dict:
     """
-    Sync a closed inspection to QualityQcFa.
+    Sync a closed inspection to quality_data tables.
 
-    Flow:
-    1. Find matching QualityQcFa record(s) by style and color
-    2. Count defects by type from RevisionDefect
-    3. Update or create QualityQcFa with defect totals
-    4. Sync InspectionDefect through-table records
+    Tables affected:
+    - QualityQcFa: matched by style + color + week, updates defect/status fields
+    - InspectionDefect: synced from RevisionDefect (delete + recreate)
+    - SecondsGeneral: UPSERT by style + color.name + week (common fields only)
+    - SecondsA4: UPSERT by style + color + week (common fields only)
 
     Args:
         inspection: A closed InspectionData instance
 
     Returns:
-        dict with keys: matched_records, synced_defects, status
+        dict with keys: matched_records, synced_defects, status,
+              total_defects, seconds_general, seconds_a4
     """
     if not inspection.is_closed:
         raise ValueError("Inspection must be closed before bridging.")
 
     with transaction.atomic():
-        # Find matching QC records by style and color
+        # ── SecondsGeneral UPSERT (always attempted, even on no QC match) ──
+        sg_result = _bridge_seconds_general(inspection)
+
+        # ── SecondsA4 UPSERT (always attempted, even on no QC match) ──
+        sa4_result = _bridge_seconds_a4(inspection)
+
+        # ── QualityQcFa matching by style + color + week ──
         qc_records = QualityQcFa.objects.filter(
             style__iexact=inspection.style,
             color=inspection.color,
+            week=inspection.week,
         )
 
         if not qc_records.exists():
@@ -50,15 +62,18 @@ def bridge_inspection(inspection: InspectionData) -> dict:
                 "matched_records": 0,
                 "synced_defects": 0,
                 "status": "no_match",
+                "total_defects": 0,
+                "seconds_general": sg_result,
+                "seconds_a4": sa4_result,
                 "message": (
                     f"No QualityQcFa record found for "
-                    f"style='{inspection.style}', color='{inspection.color}'"
+                    f"style='{inspection.style}', color='{inspection.color}', "
+                    f"week={inspection.week}"
                 ),
             }
 
         # Aggregate defects from RevisionDefect
         defect_counts = _aggregate_defects(inspection)
-
         total_defects = sum(defect_counts.values())
 
         # Update each matching record
@@ -72,6 +87,7 @@ def bridge_inspection(inspection: InspectionData) -> dict:
             )
             qc_record.defects_total = total_defects
             qc_record.pass_or_fail = inspection.status
+            qc_record.date_1 = inspection.closed_at.date().isoformat()
             qc_record.save()
 
             # Sync individual defect types to InspectionDefect
@@ -82,7 +98,93 @@ def bridge_inspection(inspection: InspectionData) -> dict:
             "synced_defects": synced,
             "status": "synced",
             "total_defects": total_defects,
+            "seconds_general": sg_result,
+            "seconds_a4": sa4_result,
         }
+
+
+def _bridge_seconds_general(inspection: InspectionData) -> dict:
+    """
+    UPSERT a SecondsGeneral record with common fields from the inspection.
+
+    Matches by (style, color.name, week). Fills date, week, style, color,
+    and size. Production fields (produced, fixed, definitive, etc.) are
+    NEVER overwritten — they stay at their existing values or default 0.
+
+    Returns:
+        dict with keys: created, updated, record_id
+    """
+    defaults = {
+        "date": inspection.date.isoformat(),
+        "size": inspection.size,
+    }
+
+    record, created = SecondsGeneral.objects.update_or_create(
+        style=inspection.style,
+        color=inspection.color.name,
+        week=inspection.week,
+        defaults=defaults,
+    )
+
+    return {
+        "created": created,
+        "updated": not created,
+        "record_id": record.pk,
+    }
+
+
+def _bridge_seconds_a4(inspection: InspectionData) -> dict:
+    """
+    UPSERT a SecondsA4 record with common fields from the inspection.
+
+    Matches by (style, color, week). Fills year, week, date, style, and
+    color. Production fields (cut_num, cut_qty, sew_def, fab_def, etc.)
+    are NEVER overwritten — they stay at existing values or 0.
+
+    Uses get_or_create + conditional update to avoid overwriting
+    production fields that lack DB defaults (SecondsA4 has many
+    IntegerField without default=0).
+
+    Returns:
+        dict with keys: created, updated, record_id
+    """
+    record, created = SecondsA4.objects.get_or_create(
+        style=inspection.style,
+        color=inspection.color,
+        week=inspection.week,
+        defaults={
+            "year": inspection.closed_at.year,
+            "date": inspection.date.isoformat(),
+            "line": "",
+            "cut_num": 0,
+            "cut_qty": 0,
+            "first_quality_qty_sewing": 0,
+            "sample": 0,
+            "pass_field": 0,
+            "fail_field": 0,
+            "sew_def": 0,
+            "fab_def": 0,
+            "accepted": 0,
+            "rejected": 0,
+            "total_of_2ds": 0,
+            "percentage_of_2ds": 0.0,
+            "seconds_by_sew": 0,
+            "seconds_by_fab": 0,
+            "seconds_sew_a4": 0,
+            "seconds_fab_a4": 0,
+        },
+    )
+
+    if not created:
+        # Only update common fields (never touch production fields)
+        record.date = inspection.date.isoformat()
+        record.save(update_fields=["date"])
+
+    return {
+        "created": created,
+        "updated": not created,
+        "record_id": record.pk,
+    }
 
 
 def _aggregate_defects(inspection: InspectionData) -> dict:

--- a/backend/media_data/inspection_bridge.py
+++ b/backend/media_data/inspection_bridge.py
@@ -19,8 +19,30 @@ from quality_data.models import (
     DefectType,
     SecondsGeneral,
     SecondsA4,
+    SecondsGeneralDefectType,
+    SecondsGeneralDefect,
 )
 from media_data.models import InspectionData, RevisionDefect
+
+
+# Mapping from garment defect types (English, from QC FA Plant)
+# to seconds defect types (Spanish, from Seconds General).
+# Built from Excel header translations in sheet_configs.py REMAP dicts.
+GARMENT_TO_SECONDS_DEFECT_MAP = {
+    "contamination": "contamination",
+    "mill_flaw": "mill_flaw",
+    "tear": "desgarre_def_tela",
+    "out_of_measurements": "fuera_medidas",
+    "hitched": "enganche",
+    "fabric_run": "corrido",
+    "stain_oil_soil": "manchas_sucio",
+    "dirt_marck": "manchas_sucio",
+    "broken_stitch": "costura_torcida_insegura",
+    "incorrect_stitch": "costura_torcida_insegura",
+    "run_off_stitch": "costura_torcida_insegura",
+    "neddle_holes": "picado_aguja",
+    "open_seam": "hoyos_costura",
+}
 
 
 def bridge_inspection(inspection: InspectionData) -> dict:
@@ -125,6 +147,9 @@ def _bridge_seconds_general(inspection: InspectionData) -> dict:
         week=inspection.week,
         defaults=defaults,
     )
+
+    # Sync garment defects to seconds defects where names overlap
+    _sync_seconds_defects(record, inspection)
 
     return {
         "created": created,
@@ -247,6 +272,66 @@ def _sync_defect_types(
         InspectionDefect.objects.create(
             inspection=qc_record,
             defect_type=defect_type,
+            amount=amount,
+        )
+        synced += 1
+
+    return synced
+
+
+def _sync_seconds_defects(
+    sg_record: SecondsGeneral,
+    inspection: InspectionData,
+) -> int:
+    """
+    Sync garment defects to SecondsGeneralDefect where names overlap.
+
+    Uses GARMENT_TO_SECONDS_DEFECT_MAP to translate garment defect type
+    names (English) to seconds defect type names (Spanish). Only maps
+    types that exist in both the garment DefectType table AND the
+    SecondsGeneralDefectType table.
+
+    Existing SecondsGeneralDefect records for this SecondsGeneral are
+    deleted and recreated to keep the mapping clean.
+
+    Returns:
+        Number of SecondsGeneralDefect records created.
+    """
+    # Aggregate RevisionDefect counts by garment defect type name
+    garment_counts = {}
+    for rd in RevisionDefect.objects.filter(
+        inspection=inspection,
+        defect_type__isnull=False,
+    ).select_related('defect_type'):
+        name = rd.defect_type.name
+        garment_counts[name] = garment_counts.get(name, 0) + rd.defect_count
+
+    # Build lookup: seconds defect type name → SecondsGeneralDefectType instance
+    mapped_names = set(GARMENT_TO_SECONDS_DEFECT_MAP.values())
+    seconds_types = {
+        st.name: st
+        for st in SecondsGeneralDefectType.objects.filter(name__in=mapped_names)
+    }
+
+    # Delete existing defects for this SecondsGeneral record
+    SecondsGeneralDefect.objects.filter(seconds_general=sg_record).delete()
+
+    synced = 0
+    for garment_name, amount in garment_counts.items():
+        seconds_name = GARMENT_TO_SECONDS_DEFECT_MAP.get(garment_name)
+        if seconds_name is None:
+            continue
+
+        seconds_type = seconds_types.get(seconds_name)
+        if seconds_type is None:
+            continue
+
+        if amount <= 0:
+            continue
+
+        SecondsGeneralDefect.objects.create(
+            seconds_general=sg_record,
+            defect_type=seconds_type,
             amount=amount,
         )
         synced += 1

--- a/backend/media_data/tests/test_inspection_bridge.py
+++ b/backend/media_data/tests/test_inspection_bridge.py
@@ -16,6 +16,7 @@ from django.contrib.auth.models import User
 from quality_data.models import (
     Color, DefectType, QualityQcFa, InspectionDefect,
     SecondsGeneral, SecondsA4,
+    SecondsGeneralDefectType, SecondsGeneralDefect,
 )
 from media_data.models import InspectionData, RevisionDefect
 
@@ -733,3 +734,86 @@ class BridgeTransactionTest(TestCase):
         self.qc.refresh_from_db()
         self.assertEqual(self.qc.defects_total, 2)
         self.assertEqual(self.qc.pass_or_fail, 'REJECT')
+
+
+class SecondsGeneralDefectSyncTest(TestCase):
+    """Garment defects synced to SecondsGeneralDefect via semantic mapping."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='op', password='123')
+        self.color = Color.objects.create(name="Map-Test", is_active=True)
+        # Create garment defect types (English names)
+        self.g_tear = DefectType.objects.create(name="tear", is_active=True)
+        self.g_hitched = DefectType.objects.create(name="hitched", is_active=True)
+        self.g_unknown = DefectType.objects.create(name="label_slanted", is_active=True)
+        # Create seconds defect types (Spanish names)
+        self.s_desgarre, _ = SecondsGeneralDefectType.objects.get_or_create(
+            name="desgarre_def_tela"
+        )
+        self.s_enganche, _ = SecondsGeneralDefectType.objects.get_or_create(
+            name="enganche"
+        )
+
+        self.inspection = InspectionData.objects.create(
+            inspector=self.user,
+            color=self.color,
+            style="MAP-STYLE",
+            size="L",
+            closed_at=timezone.now(),
+            is_closed=True,
+            status='REJECT',
+        )
+        # Garment defects: tear=5, hitched=3, label_slanted=1 (no mapping)
+        RevisionDefect.objects.create(
+            inspection=self.inspection, inspector=self.user,
+            defect_type=self.g_tear, defect_size="M", defect_count=5,
+        )
+        RevisionDefect.objects.create(
+            inspection=self.inspection, inspector=self.user,
+            defect_type=self.g_hitched, defect_size="S", defect_count=3,
+        )
+        RevisionDefect.objects.create(
+            inspection=self.inspection, inspector=self.user,
+            defect_type=self.g_unknown, defect_size="L", defect_count=1,
+        )
+
+    def test_maps_garment_defects_to_seconds_defects(self):
+        """tear→desgarre_def_tela(5), hitched→enganche(3), label_slanted ignored."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        result = bridge_inspection(self.inspection)
+        sg_result = result['seconds_general']
+
+        sg = SecondsGeneral.objects.get(pk=sg_result['record_id'])
+        defects = SecondsGeneralDefect.objects.filter(seconds_general=sg)
+
+        self.assertEqual(defects.count(), 2)
+
+        d1 = defects.get(defect_type__name="desgarre_def_tela")
+        self.assertEqual(d1.amount, 5)
+
+        d2 = defects.get(defect_type__name="enganche")
+        self.assertEqual(d2.amount, 3)
+
+    def test_seconds_defects_recreated_on_re_bridge(self):
+        """Re-bridging deletes old defects and recreates them."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        # First bridge
+        bridge_inspection(self.inspection)
+
+        # Add a new RevisionDefect
+        RevisionDefect.objects.create(
+            inspection=self.inspection, inspector=self.user,
+            defect_type=self.g_tear, defect_size="M", defect_count=2,
+        )
+        # Total tear should now be 7
+
+        # Second bridge
+        result = bridge_inspection(self.inspection)
+        sg = SecondsGeneral.objects.get(pk=result['seconds_general']['record_id'])
+
+        d = SecondsGeneralDefect.objects.get(
+            seconds_general=sg, defect_type__name="desgarre_def_tela"
+        )
+        self.assertEqual(d.amount, 7)

--- a/backend/media_data/tests/test_inspection_bridge.py
+++ b/backend/media_data/tests/test_inspection_bridge.py
@@ -11,9 +11,17 @@ Tests cover:
 - Edge cases: zero defects, sample < defects, null defect_type
 """
 from django.test import TestCase
+from django.utils import timezone
 from django.contrib.auth.models import User
-from quality_data.models import Color, DefectType, QualityQcFa, InspectionDefect
+from quality_data.models import (
+    Color, DefectType, QualityQcFa, InspectionDefect,
+    SecondsGeneral, SecondsA4,
+)
 from media_data.models import InspectionData, RevisionDefect
+
+
+def _current_week():
+    return timezone.now().date().isocalendar()[1]
 
 
 class InspectionBridgeUnclosedTest(TestCase):
@@ -50,6 +58,7 @@ class InspectionBridgeNoMatchTest(TestCase):
             color=self.color,
             style="NONEXISTENT-STYLE",
             size="M",
+            closed_at=timezone.now(),
             is_closed=True,
             status='PASS',
         )
@@ -77,7 +86,7 @@ class InspectionBridgeSingleRecordTest(TestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -100,6 +109,7 @@ class InspectionBridgeSingleRecordTest(TestCase):
             color=self.color,
             style="POLO-2026",
             size="XL",
+            closed_at=timezone.now(),
             is_closed=True,
             status='REJECT',
         )
@@ -148,7 +158,7 @@ class InspectionBridgeMultipleRecordsTest(TestCase):
         self.qc_record_1 = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -168,7 +178,7 @@ class InspectionBridgeMultipleRecordsTest(TestCase):
         self.qc_record_2 = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -191,6 +201,7 @@ class InspectionBridgeMultipleRecordsTest(TestCase):
             color=self.color,
             style="SHIRT-2026",
             size="L",
+            closed_at=timezone.now(),
             is_closed=True,
             status='REJECT',
         )
@@ -230,6 +241,7 @@ class InspectionBridgeDefectAggregationTest(TestCase):
             color=self.color,
             style="JEANS-2026",
             size="32",
+            closed_at=timezone.now(),
             is_closed=True,
         )
         # 5 + 3 = 8 of type_A, 2 of type_B
@@ -276,7 +288,7 @@ class InspectionBridgeInspectionDefectSyncTest(TestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -299,6 +311,7 @@ class InspectionBridgeInspectionDefectSyncTest(TestCase):
             color=self.color,
             style="TEST-STYLE",
             size="M",
+            closed_at=timezone.now(),
             is_closed=True,
             status='REJECT',
         )
@@ -348,7 +361,7 @@ class InspectionBridgeInactiveDefectTypesTest(TestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -391,7 +404,7 @@ class InspectionBridgeEdgeCasesTest(TestCase):
         self.qc_record_small_sample = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -417,7 +430,7 @@ class InspectionBridgeEdgeCasesTest(TestCase):
         qc_zero = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=_current_week(),
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -440,6 +453,7 @@ class InspectionBridgeEdgeCasesTest(TestCase):
             color=self.color,
             style="ZERO-DEFECTS",
             size="S",
+            closed_at=timezone.now(),
             is_closed=True,
             status='PASS',
         )
@@ -464,6 +478,7 @@ class InspectionBridgeEdgeCasesTest(TestCase):
             color=self.color,
             style="EDGE-CASE-SMALL",
             size="M",
+            closed_at=timezone.now(),
             is_closed=True,
             status='REJECT',
         )
@@ -490,6 +505,7 @@ class InspectionBridgeEdgeCasesTest(TestCase):
             color=self.color,
             style="EDGE-CASE",
             size="L",
+            closed_at=timezone.now(),
             is_closed=True,
         )
         # One with null defect_type
@@ -514,3 +530,206 @@ class InspectionBridgeEdgeCasesTest(TestCase):
         # Null type excluded, only "Minor" = 1
         self.assertEqual(len(counts), 1)
         self.assertEqual(counts["Minor"], 1)
+
+
+class SecondsGeneralBridgeTest(TestCase):
+    """SecondsGeneral UPSERT from inspection data."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='op', password='123')
+        self.color = Color.objects.create(name="SG-Test", is_active=True)
+        self.inspection = InspectionData.objects.create(
+            inspector=self.user,
+            color=self.color,
+            style="SG-STYLE",
+            size="XL",
+            closed_at=timezone.now(),
+            is_closed=True,
+            status='PASS',
+        )
+
+    def test_seconds_general_upsert_creates_new_record(self):
+        """SecondsGeneral created with common fields when no match exists."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        result = bridge_inspection(self.inspection)
+
+        self.assertIn('seconds_general', result)
+        sg = SecondsGeneral.objects.get(
+            style="SG-STYLE",
+            color="SG-Test",
+            week=_current_week(),
+        )
+        self.assertEqual(sg.date, self.inspection.date.isoformat())
+        self.assertEqual(sg.size, "XL")
+        # Production fields stay at defaults
+        self.assertEqual(sg.produced, 0)
+        self.assertEqual(sg.fixed, 0)
+
+    def test_seconds_general_upsert_preserves_production_fields(self):
+        """Re-bridging does NOT overwrite production fields."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        # First bridge: create record
+        bridge_inspection(self.inspection)
+
+        # Manually set production field
+        sg = SecondsGeneral.objects.get(
+            style="SG-STYLE", color="SG-Test", week=_current_week(),
+        )
+        sg.produced = 500
+        sg.save()
+
+        # Second bridge: should NOT overwrite produced
+        bridge_inspection(self.inspection)
+
+        sg.refresh_from_db()
+        self.assertEqual(sg.produced, 500)
+
+
+class SecondsA4BridgeTest(TestCase):
+    """SecondsA4 UPSERT from inspection data."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='op', password='123')
+        self.color = Color.objects.create(name="A4-Test", is_active=True)
+        self.inspection = InspectionData.objects.create(
+            inspector=self.user,
+            color=self.color,
+            style="A4-STYLE",
+            size="M",
+            closed_at=timezone.now(),
+            is_closed=True,
+            status='PASS',
+        )
+
+    def test_seconds_a4_upsert_creates_new_record(self):
+        """SecondsA4 created with common fields."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        result = bridge_inspection(self.inspection)
+
+        self.assertIn('seconds_a4', result)
+        a4 = SecondsA4.objects.get(
+            style="A4-STYLE",
+            color=self.color,
+            week=_current_week(),
+        )
+        self.assertEqual(a4.date, self.inspection.date.isoformat())
+
+    def test_seconds_a4_upsert_preserves_production_fields(self):
+        """Re-bridging preserves cut_qty."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        bridge_inspection(self.inspection)
+
+        a4 = SecondsA4.objects.get(
+            style="A4-STYLE", color=self.color, week=_current_week(),
+        )
+        a4.cut_qty = 300
+        a4.save()
+
+        bridge_inspection(self.inspection)
+
+        a4.refresh_from_db()
+        self.assertEqual(a4.cut_qty, 300)
+
+
+class QualityQcFaWeekMatchTest(TestCase):
+    """Week-based matching for QualityQcFa."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='op', password='123')
+        self.color = Color.objects.create(name="Week-Test", is_active=True)
+        self.current_week = _current_week()
+        self.other_week = self.current_week + 1
+        if self.other_week > 52:
+            self.other_week = 1
+
+    def test_same_week_matches(self):
+        """QC record with same week is matched and updated."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        qc = QualityQcFa.objects.create(
+            table_type="QFA", date_1="2025-01-15",
+            week=self.current_week, customer="Cust", team=1, coord="C",
+            po=1, style="WEEK-STYLE", batch=1, color=self.color,
+            qty=100, seconds=0, accepted=100, rejected=0, sample=100,
+            defects_total=0, aql=0, pass_or_fail="PASS",
+        )
+
+        inspection = InspectionData.objects.create(
+            inspector=self.user, color=self.color,
+            style="WEEK-STYLE", size="M",
+            closed_at=timezone.now(), is_closed=True, status='REJECT',
+        )
+
+        result = bridge_inspection(inspection)
+        self.assertEqual(result['status'], 'synced')
+        self.assertEqual(result['matched_records'], 1)
+
+        qc.refresh_from_db()
+        self.assertEqual(qc.pass_or_fail, 'REJECT')
+        self.assertEqual(qc.date_1, inspection.closed_at.date().isoformat())
+
+    def test_cross_week_blocked(self):
+        """QC record with different week is NOT matched."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        QualityQcFa.objects.create(
+            table_type="QFA", date_1="2025-01-15",
+            week=self.other_week, customer="Cust", team=1, coord="C",
+            po=1, style="WEEK-STYLE-2", batch=1, color=self.color,
+            qty=100, seconds=0, accepted=100, rejected=0, sample=100,
+            defects_total=0, aql=0, pass_or_fail="PASS",
+        )
+
+        inspection = InspectionData.objects.create(
+            inspector=self.user, color=self.color,
+            style="WEEK-STYLE-2", size="M",
+            closed_at=timezone.now(), is_closed=True, status='REJECT',
+        )
+
+        result = bridge_inspection(inspection)
+        self.assertEqual(result['status'], 'no_match')
+
+
+class BridgeTransactionTest(TestCase):
+    """Transaction atomicity for bridge."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='op', password='123')
+        self.color = Color.objects.create(name="Tx-Test", is_active=True)
+        self.defect_type = DefectType.objects.create(name="TxDefect", is_active=True)
+
+        self.qc = QualityQcFa.objects.create(
+            table_type="QFA", date_1="2025-01-15",
+            week=_current_week(), customer="Cust", team=1, coord="C",
+            po=1, style="TX-STYLE", batch=1, color=self.color,
+            qty=100, seconds=0, accepted=100, rejected=0, sample=100,
+            defects_total=0, aql=0, pass_or_fail="PASS",
+        )
+
+        self.inspection = InspectionData.objects.create(
+            inspector=self.user, color=self.color,
+            style="TX-STYLE", size="L",
+            closed_at=timezone.now(), is_closed=True, status='REJECT',
+        )
+        RevisionDefect.objects.create(
+            inspection=self.inspection, inspector=self.user,
+            defect_type=self.defect_type, defect_size="M", defect_count=2,
+        )
+
+    def test_all_tables_populated_in_single_transaction(self):
+        """QC, SG, SA4 all populated."""
+        from media_data.inspection_bridge import bridge_inspection
+
+        result = bridge_inspection(self.inspection)
+
+        self.assertEqual(result['status'], 'synced')
+        self.assertIn('seconds_general', result)
+        self.assertIn('seconds_a4', result)
+
+        self.qc.refresh_from_db()
+        self.assertEqual(self.qc.defects_total, 2)
+        self.assertEqual(self.qc.pass_or_fail, 'REJECT')

--- a/backend/media_data/tests/test_views.py
+++ b/backend/media_data/tests/test_views.py
@@ -10,6 +10,7 @@ Tests cover:
 
 from django.contrib.auth.models import User
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 from quality_data.models import Color, DefectType, QualityQcFa
@@ -59,7 +60,7 @@ class CloseInspectionWithDefectsTest(APITestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=timezone.now().date().isocalendar()[1],
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -137,7 +138,7 @@ class CloseInspectionWithoutDefectsTest(APITestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=timezone.now().date().isocalendar()[1],
             customer="Test Customer",
             team=1,
             coord="Coord1",
@@ -209,7 +210,7 @@ class CloseInspectionBridgeSyncTest(APITestCase):
         self.qc_record = QualityQcFa.objects.create(
             table_type="QFA",
             date_1="2025-01-15",
-            week=3,
+            week=timezone.now().date().isocalendar()[1],
             customer="Test Customer",
             team=1,
             coord="Coord1",


### PR DESCRIPTION
## Summary
- Refactoriza `inspection_bridge.py` para llenar campos comunes en **SecondsGeneral** y **SecondsA4** además de QualityQcFa
- Mejora el matching de QualityQcFa agregando **week** (style+color+week en vez de style+color)
- Agrega `date_1` a los campos actualizados en QualityQcFa
- Protege campos de producción (produced, fixed, cut_qty, etc.) — nunca se sobreescriben

## Changes

| Tabla | Antes | Ahora |
|-------|-------|-------|
| QualityQcFa | 4 campos, match style+color | 5 campos + **week** en matching + `date_1` |
| InspectionDefect | 3/3 (delete+recreate) | Igual ✅ |
| SecondsGeneral | ❌ No se tocaba | ✅ UPSERT 5 campos (date, week, style, color, size) |
| SecondsA4 | ❌ No se tocaba | ✅ UPSERT 5 campos (year, week, date, style, color) |

## Test Plan
- [x] 18/18 bridge tests
- [x] Nuevos tests: SecondsGeneral UPSERT, SecondsA4 UPSERT, week matching, cross-week isolation, production preservation