### PR TITLE
fix(backend): volatile sort error + Excel preview performance

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -159,6 +159,8 @@ CACHES = {
         "LOCATION": "redis://redis:6379/1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SOCKET_CONNECT_TIMEOUT": 2,
+            "SOCKET_TIMEOUT": 2,
         }
     }
 }

--- a/backend/excel_importer/handler_service.py
+++ b/backend/excel_importer/handler_service.py
@@ -87,16 +87,12 @@ def load_and_clean(file_obj, remap_columns, numeric_columns, defeacts_fields, sh
     else:
         file_obj.seek(0)
         try:
-            df = pd.read_excel(file_obj, engine='calamine', sheet_name=sheet, header=header, usecols=range(cols))
-        except (ValueError, ImportError):
+            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(cols))
+        except ValueError:
             file_obj.seek(0)
-            try:
-                df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(cols))
-            except ValueError:
-                file_obj.seek(0)
-                df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header)
-                if df.shape[1] > cols:
-                    df = df.iloc[:, :cols]
+            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header)
+            if df.shape[1] > cols:
+                df = df.iloc[:, :cols]
 
     df = df.dropna(how='all').dropna(axis=1, how='all')
     df = df.rename(columns=remap_columns)

--- a/backend/excel_importer/handler_service.py
+++ b/backend/excel_importer/handler_service.py
@@ -75,18 +75,24 @@ def load_and_clean(file_obj, remap_columns, numeric_columns, defeacts_fields, sh
     defeacts_fields = _normalize_defects_fields(defeacts_fields)
 
     if excel_file is not None:
-        # Read all columns, then slice to expected count.
-        # No need for preview read — ExcelFile reads are fast.
-        df = pd.read_excel(excel_file, sheet_name=sheet, header=header)
-        if df.shape[1] > cols:
-            df = df.iloc[:, :cols]
+        # Try with usecols first (fast path). If the sheet has fewer columns
+        # than expected, pandas raises ValueError. Fall back to reading all
+        # columns and slicing.
+        try:
+            df = pd.read_excel(excel_file, sheet_name=sheet, header=header, usecols=range(cols))
+        except ValueError:
+            df = pd.read_excel(excel_file, sheet_name=sheet, header=header)
+            if df.shape[1] > cols:
+                df = df.iloc[:, :cols]
     else:
         file_obj.seek(0)
-        preview = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, nrows=0)
-        file_obj.seek(0)
-        actual_cols = preview.shape[1]
-        read_cols = min(cols, actual_cols) if actual_cols > 0 else cols
-        df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(read_cols))
+        try:
+            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(cols))
+        except ValueError:
+            file_obj.seek(0)
+            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header)
+            if df.shape[1] > cols:
+                df = df.iloc[:, :cols]
 
     df = df.dropna(how='all').dropna(axis=1, how='all')
     df = df.rename(columns=remap_columns)

--- a/backend/excel_importer/handler_service.py
+++ b/backend/excel_importer/handler_service.py
@@ -75,12 +75,11 @@ def load_and_clean(file_obj, remap_columns, numeric_columns, defeacts_fields, sh
     defeacts_fields = _normalize_defects_fields(defeacts_fields)
 
     if excel_file is not None:
-        # Detect actual column count to avoid out-of-bounds usecols errors
-        # when the sheet has fewer columns than expected.
-        preview = pd.read_excel(excel_file, sheet_name=sheet, header=header, nrows=0)
-        actual_cols = preview.shape[1]
-        read_cols = min(cols, actual_cols) if actual_cols > 0 else cols
-        df = pd.read_excel(excel_file, sheet_name=sheet, header=header, usecols=range(read_cols))
+        # Read all columns, then slice to expected count.
+        # No need for preview read — ExcelFile reads are fast.
+        df = pd.read_excel(excel_file, sheet_name=sheet, header=header)
+        if df.shape[1] > cols:
+            df = df.iloc[:, :cols]
     else:
         file_obj.seek(0)
         preview = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, nrows=0)

--- a/backend/excel_importer/handler_service.py
+++ b/backend/excel_importer/handler_service.py
@@ -87,12 +87,16 @@ def load_and_clean(file_obj, remap_columns, numeric_columns, defeacts_fields, sh
     else:
         file_obj.seek(0)
         try:
-            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(cols))
-        except ValueError:
+            df = pd.read_excel(file_obj, engine='calamine', sheet_name=sheet, header=header, usecols=range(cols))
+        except (ValueError, ImportError):
             file_obj.seek(0)
-            df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header)
-            if df.shape[1] > cols:
-                df = df.iloc[:, :cols]
+            try:
+                df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header, usecols=range(cols))
+            except ValueError:
+                file_obj.seek(0)
+                df = pd.read_excel(file_obj, engine='openpyxl', sheet_name=sheet, header=header)
+                if df.shape[1] > cols:
+                    df = df.iloc[:, :cols]
 
     df = df.dropna(how='all').dropna(axis=1, how='all')
     df = df.rename(columns=remap_columns)

--- a/backend/excel_importer/sync_service.py
+++ b/backend/excel_importer/sync_service.py
@@ -560,7 +560,7 @@ def create_session_from_dataframes(dataframes):
     qfa_plant_dates = extract_dates(qc_fa_plant_rows, "date_1")
     session.qc_fa_plant_preview = compute_preview_timewindow(
         qc_fa_plant_rows,
-        QualityQcFa.objects.filter(table_type="QFA", date_1__in=qfa_plant_dates)
+        QualityQcFa.objects.filter(table_type="QFA", date_1__in=qfa_plant_dates).select_related('color')
         if qfa_plant_dates else QualityQcFa.objects.none(),
         date_field="date_1",
     )
@@ -569,7 +569,7 @@ def create_session_from_dataframes(dataframes):
     qfa_customer_dates = extract_dates(qc_fa_customer_rows, "date_1")
     session.qc_fa_customer_preview = compute_preview_timewindow(
         qc_fa_customer_rows,
-        QualityQcFa.objects.filter(table_type="QFC", date_1__in=qfa_customer_dates)
+        QualityQcFa.objects.filter(table_type="QFC", date_1__in=qfa_customer_dates).select_related('color')
         if qfa_customer_dates else QualityQcFa.objects.none(),
         date_field="date_1",
     )
@@ -578,7 +578,7 @@ def create_session_from_dataframes(dataframes):
     seconds_a4_dates = extract_dates(seconds_a4_rows, "date")
     session.seconds_a4_preview = compute_preview_upsert(
         seconds_a4_rows,
-        SecondsA4.objects.filter(date__in=seconds_a4_dates)
+        SecondsA4.objects.filter(date__in=seconds_a4_dates).select_related('color')
         if seconds_a4_dates else SecondsA4.objects.none(),
         key_builder=build_seconds_a4_key,
         date_field="date",

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -63,38 +63,24 @@ def _df_to_json_safe(df):
     """
     Convert a DataFrame to a list of dicts with JSON-serializable values.
 
-    Handles:
-    - pandas.Timestamp / datetime → ISO date string (YYYY-MM-DD)
-    - numpy.integer / numpy.floating → Python int / float
-    - numpy.bool_ → Python bool
-    - pandas.NaT / None → None
+    Uses vectorized pandas operations instead of row-by-row Python iteration.
+    Handles: Timestamp → ISO date, NaN → None, numpy types → Python types.
     """
     if df is None or df.empty:
         return []
 
-    records = df.to_dict('records')
-    result = []
-    for row in records:
-        clean_row = {}
-        for key, value in row.items():
-            if value is None or pd.isna(value):
-                clean_row[key] = None
-            elif isinstance(value, (pd.Timestamp, datetime.datetime)):
-                clean_row[key] = value.strftime("%Y-%m-%d")
-            elif isinstance(value, datetime.date):
-                clean_row[key] = value.strftime("%Y-%m-%d")
-            elif isinstance(value, (np.integer,)):
-                clean_row[key] = int(value)
-            elif isinstance(value, (np.floating,)):
-                clean_row[key] = float(value)
-            elif isinstance(value, (np.bool_,)):
-                clean_row[key] = bool(value)
-            elif isinstance(value, np.ndarray):
-                clean_row[key] = value.tolist()
-            else:
-                clean_row[key] = value
-        result.append(clean_row)
-    return result
+    # Work on a copy to avoid mutating the original
+    df = df.copy()
+
+    # Convert datetime columns to ISO date strings (vectorized)
+    for col in df.select_dtypes(include=['datetime64', 'datetimetz']).columns:
+        df[col] = df[col].dt.strftime('%Y-%m-%d')
+
+    # Replace NaN/NaT with None for JSON compatibility
+    df = df.where(pd.notna(df), None)
+
+    # Convert to dicts — pandas already handles numpy→Python type conversion
+    return df.to_dict('records')
 
 
 def _serialize_payload(serializer_cls, payload, many=False):
@@ -198,12 +184,9 @@ class ExcelPreviewView(APIView):
             # Gracefully fall back to per-sheet reading if ExcelFile creation fails
             # (e.g. invalid file, test mocks with /dev/null, etc.)
             try:
-                excel_file = pd.ExcelFile(file_obj, engine='calamine')
+                excel_file = pd.ExcelFile(file_obj, engine='openpyxl')
             except Exception:
-                try:
-                    excel_file = pd.ExcelFile(file_obj, engine='openpyxl')
-                except Exception:
-                    excel_file = None
+                excel_file = None
 
             # Parse all 5 sheets
             dataframes = {}

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -1529,9 +1529,9 @@ class VolatileKpiView(APIView):
                 options[field] = []
 
         if 'color__name' in df.columns:
-            options['color'] = sorted(df['color__name'].dropna().unique().tolist())
+            options['color'] = sorted([str(x) for x in df['color__name'].dropna().unique().tolist()])
         elif 'color' in df.columns:
-            options['color'] = sorted(df['color'].dropna().unique().tolist())
+            options['color'] = sorted([str(x) for x in df['color'].dropna().unique().tolist()])
         else:
             options['color'] = []
 

--- a/backend/quality_data/views.py
+++ b/backend/quality_data/views.py
@@ -198,9 +198,12 @@ class ExcelPreviewView(APIView):
             # Gracefully fall back to per-sheet reading if ExcelFile creation fails
             # (e.g. invalid file, test mocks with /dev/null, etc.)
             try:
-                excel_file = pd.ExcelFile(file_obj, engine='openpyxl')
+                excel_file = pd.ExcelFile(file_obj, engine='calamine')
             except Exception:
-                excel_file = None
+                try:
+                    excel_file = pd.ExcelFile(file_obj, engine='openpyxl')
+                except Exception:
+                    excel_file = None
 
             # Parse all 5 sheets
             dataframes = {}


### PR DESCRIPTION
## Summary
- Fix `sorted()` TypeError en `_compute_filter_options` cuando `color` tiene valores numéricos mezclados con strings
- Agrega `SOCKET_CONNECT_TIMEOUT=2s` a Redis (antes ∞, causaba 30-60s de delay)
- `select_related('color')` en queries de preview (elimina N+1 queries)
- Vectoriza `_df_to_json_safe` (O(n×m) Python → pandas vectorizado)
- Fix `usecols` out-of-bounds en `load_and_clean` para sheets con columnas variables

## Test Plan
- [x] 357/357 backend tests
- [x] volatile KPI: 21/21
- [x] Excel V2: 14/14